### PR TITLE
Improve forecast etl performance

### DIFF
--- a/air-quality-backend/liquibase/forecast_data.xml
+++ b/air-quality-backend/liquibase/forecast_data.xml
@@ -12,18 +12,18 @@
     <mongodb:createCollection collectionName="forecast_data"/>
     <mongodb:createIndex collectionName="forecast_data">
       <mongodb:keys>
-        { measurement_date: 1, city: 1}
+        { measurement_date: 1, name: 1}
       </mongodb:keys>
       <mongodb:options>
-        {unique: true, name: "measurement_date_1_city_1"}
+        {unique: true, name: "measurement_date_1_name_1"}
       </mongodb:options>
     </mongodb:createIndex>
     <mongodb:createIndex collectionName="forecast_data">
       <mongodb:keys>
-        { city_location: "2dsphere" }
+        { location: "2dsphere" }
       </mongodb:keys>
       <mongodb:options>
-        { name: "city_location_2dsphere" }
+        { name: "location_2dsphere" }
       </mongodb:options>
     </mongodb:createIndex>
   </changeSet>

--- a/air-quality-backend/scripts/run_forecast_etl.py
+++ b/air-quality-backend/scripts/run_forecast_etl.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from dotenv import load_dotenv
 import logging
 from logging import config
-from src.database import (
+from src.database.air_quality_dashboard_dao import (
     get_locations_by_type,
     insert_data_forecast,
 )

--- a/air-quality-backend/scripts/run_forecast_etl.py
+++ b/air-quality-backend/scripts/run_forecast_etl.py
@@ -1,5 +1,7 @@
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from dotenv import load_dotenv
+from itertools import chain
 import logging
 from logging import config
 from src.database.air_quality_dashboard_dao import (
@@ -24,7 +26,12 @@ def main():
     extracted_forecast_data = fetch_forecast_data(model_base_date=today)
 
     logging.info("Transforming forecast data")
-    transformed_forecast_data = transform(extracted_forecast_data, cities)
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [
+            executor.submit(transform, extracted_forecast_data, city) for city in cities
+        ]
+        results = [future.result() for future in futures]
+    transformed_forecast_data = list(chain.from_iterable(results))
 
     logging.info("Persisting forecast data")
     insert_data_forecast(transformed_forecast_data)

--- a/air-quality-backend/scripts/run_in_situ_etl.py
+++ b/air-quality-backend/scripts/run_in_situ_etl.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import logging
 from logging import config
-from src.database import (
+from src.database.air_quality_dashboard_dao import (
     get_locations_by_type,
     insert_data_openaq,
 )

--- a/air-quality-backend/scripts/run_purge_old_data.py
+++ b/air-quality-backend/scripts/run_purge_old_data.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import logging
 from logging import config
-from src.database import (
+from src.database.air_quality_dashboard_dao import (
     delete_data_before,
 )
 

--- a/air-quality-backend/src/database/air_quality_dashboard_dao.py
+++ b/air-quality-backend/src/database/air_quality_dashboard_dao.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import logging
 import os
 from pymongo import MongoClient, UpdateOne
+from .location import AirQualityLocation
 
 
 def get_collection(name: str):
@@ -19,7 +20,7 @@ def _upsert_measurement_data(collection_name, data):
     update_operations = [
         (
             UpdateOne(
-                {"city": doc["city"], "measurement_date": doc["measurement_date"]},
+                {"name": doc["name"], "measurement_date": doc["measurement_date"]},
                 [
                     {
                         "$set": {
@@ -54,7 +55,7 @@ def insert_data_openaq(data):
     _upsert_measurement_data("in_situ_data", data)
 
 
-def get_locations_by_type(location_type: str):
+def get_locations_by_type(location_type: str) -> list[AirQualityLocation]:
     collection = get_collection("locations")
     cursor = collection.find({"type": location_type})
     results = []

--- a/air-quality-backend/src/database/location.py
+++ b/air-quality-backend/src/database/location.py
@@ -1,0 +1,8 @@
+from typing import TypedDict
+
+
+class AirQualityLocation(TypedDict):
+    name: str
+    latitude: float
+    longitude: float
+    type: str

--- a/air-quality-backend/src/etl/forecast/forecast_dao.py
+++ b/air-quality-backend/src/etl/forecast/forecast_dao.py
@@ -1,29 +1,30 @@
 import cdsapi
 from datetime import datetime
 import logging
+import os
 import xarray as xr
 from .forecast_data import ForecastData
 
 
-def __get_base_request_body(model_base_date: str) -> dict:
+def __get_base_request_body(model_base_date: str, model_base_time: str) -> dict:
     leadtime_hour = [str(i) for i in range(24, 121, 3)]
     return {
         "date": f"{model_base_date}/{model_base_date}",
         "type": "forecast",
         "format": "grib",
-        "time": "00:00",
+        "time": f"{model_base_time}:00",
         "leadtime_hour": leadtime_hour,
     }
 
 
-def get_single_level_request_body(model_base_date: str) -> dict:
-    base_request = __get_base_request_body(model_base_date)
+def get_single_level_request_body(model_base_date: str, model_base_time: str) -> dict:
+    base_request = __get_base_request_body(model_base_date, model_base_time)
     base_request["variable"] = ["particulate_matter_10um", "particulate_matter_2.5um"]
     return base_request
 
 
-def get_multi_level_request_body(model_base_date: str) -> dict:
-    base_request = __get_base_request_body(model_base_date)
+def get_multi_level_request_body(model_base_date: str, model_base_time: str) -> dict:
+    base_request = __get_base_request_body(model_base_date, model_base_time)
     base_request["variable"] = ["nitrogen_dioxide", "ozone", "sulphur_dioxide"]
     base_request["model_level"] = "137"
     return base_request
@@ -32,7 +33,10 @@ def get_multi_level_request_body(model_base_date: str) -> dict:
 def fetch_cams_data(request_body, file_name) -> xr.Dataset:
     c = cdsapi.Client()
     logging.info(f"Loading data from CAMS to file {file_name}")
-    c.retrieve("cams-global-atmospheric-composition-forecasts", request_body, file_name)
+    if not os.path.exists(file_name):
+        c.retrieve(
+            "cams-global-atmospheric-composition-forecasts", request_body, file_name
+        )
     return xr.open_dataset(
         file_name, decode_times=False, engine="cfgrib", backend_kwargs={"indexpath": ""}
     )
@@ -42,10 +46,15 @@ def fetch_forecast_data(
     model_base_date: datetime,
 ) -> ForecastData:
     model_base_date_str = model_base_date.strftime("%Y-%m-%d")
+    model_base_time = "00"
+    single_file_name = f"single_level_{model_base_date_str}_{model_base_time}.grib"
+    multi_file_name = f"multi_level_{model_base_date_str}_{model_base_time}.grib"
     single_level_data = fetch_cams_data(
-        get_single_level_request_body(model_base_date_str), "single_level.grib"
+        get_single_level_request_body(model_base_date_str, model_base_time),
+        single_file_name,
     )
     multi_level_data = fetch_cams_data(
-        get_multi_level_request_body(model_base_date_str), "multi_level.grib"
+        get_multi_level_request_body(model_base_date_str, model_base_time),
+        multi_file_name,
     )
     return ForecastData(single_level_data, multi_level_data)

--- a/air-quality-backend/src/etl/forecast/forecast_dao.py
+++ b/air-quality-backend/src/etl/forecast/forecast_dao.py
@@ -1,5 +1,4 @@
 import cdsapi
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import logging
 import os
@@ -48,20 +47,15 @@ def fetch_forecast_data(
 ) -> ForecastData:
     model_base_date_str = model_base_date.strftime("%Y-%m-%d")
     model_base_time = "00"
-    single_file_name = f"single_level_{model_base_date_str}_{model_base_time}.grib"
-    multi_file_name = f"multi_level_{model_base_date_str}_{model_base_time}.grib"
     task_params = [
         (
             get_single_level_request_body(model_base_date_str, model_base_time),
-            single_file_name,
+            f"single_level_{model_base_date_str}_{model_base_time}.grib",
         ),
         (
             get_multi_level_request_body(model_base_date_str, model_base_time),
-            multi_file_name,
+            f"multi_level_{model_base_date_str}_{model_base_time}.grib",
         ),
     ]
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = [executor.submit(fetch_cams_data, *params) for params in task_params]
-        results = [future.result() for future in futures]
-
-    return ForecastData(results[0], results[1])
+    results = [fetch_cams_data(*params) for params in task_params]
+    return ForecastData(*results)

--- a/air-quality-backend/src/etl/forecast/forecast_data.py
+++ b/air-quality-backend/src/etl/forecast/forecast_data.py
@@ -12,10 +12,6 @@ def convert_east_only_longitude_to_east_west(longitude_value: float) -> float:
     return longitude_value
 
 
-def convert_kg_to_ug(x: float):
-    return float(Decimal(str(x)) * Decimal(10**9))
-
-
 def convert_dataset(dataset: xr.Dataset) -> xr.Dataset:
     converted_data = dataset.assign_coords(
         longitude=list(

--- a/air-quality-backend/src/etl/forecast/forecast_data.py
+++ b/air-quality-backend/src/etl/forecast/forecast_data.py
@@ -49,7 +49,8 @@ class ForecastData:
         self, latitude: float, longitude: float, pollutant_type: PollutantType
     ) -> list[float]:
         """
-        Get forecasted air pollutant values (kgm3) for a given lat/long and pollutant using bilinear interpolation
+        Get forecasted air pollutant values (kgm3) for a given lat/long
+        and pollutant using bilinear interpolation
         :param latitude:
         :param longitude:
         :param pollutant_type:

--- a/air-quality-backend/src/etl/forecast/forecast_data.py
+++ b/air-quality-backend/src/etl/forecast/forecast_data.py
@@ -1,20 +1,69 @@
+from decimal import Decimal
 import xarray as xr
 from src.etl.air_quality_index.pollutant_type import PollutantType, is_single_level
 
 
+def convert_east_only_longitude_to_east_west(longitude_value: float) -> float:
+    """
+    Convert longitude value from range of 0 - 360 to -180 - 180
+    """
+    if 180 < longitude_value <= 360:
+        return float(Decimal(str(longitude_value)) - Decimal("360"))
+    return longitude_value
+
+
+def convert_kg_to_ug(x: float):
+    return float(Decimal(str(x)) * Decimal(10**9))
+
+
+def convert_dataset(dataset: xr.Dataset) -> xr.Dataset:
+    converted_data = dataset.assign_coords(
+        longitude=list(
+            map(
+                lambda lon: convert_east_only_longitude_to_east_west(
+                    lon.values.flat[0]
+                ),
+                dataset.longitude,
+            )
+        )
+    )
+    converted_data = converted_data.sortby("longitude")
+    return converted_data
+
+
 class ForecastData:
     def __init__(self, single_level_data: xr.Dataset, multi_level_data: xr.Dataset):
-        self.single_level_data = single_level_data
-        self.multi_level_data = multi_level_data
+        self._single_level_data = convert_dataset(single_level_data)
+        self._multi_level_data = convert_dataset(multi_level_data)
 
-    def get_data(self, pollutant_type: PollutantType) -> xr.DataArray:
+    def _get_data_set(self, pollutant_type: PollutantType) -> xr.Dataset:
         if is_single_level(pollutant_type):
-            return self.single_level_data[pollutant_type.value]
+            return self._single_level_data
         else:
-            return self.multi_level_data[pollutant_type.value]
+            return self._multi_level_data
+
+    def get_pollutant_data_for_lat_long(
+        self, latitude: float, longitude: float, pollutant_type: PollutantType
+    ) -> list[float]:
+        """
+        Get forecasted air pollutant values (kgm3) for a given lat/long and pollutant using bilinear interpolation
+        :param latitude:
+        :param longitude:
+        :param pollutant_type:
+        :return: values for pollutant at lat/long
+        """
+        dataset = self._get_data_set(pollutant_type)
+        return dataset.interp(
+            latitude=latitude,
+            longitude=longitude,
+            method="linear",
+        )[pollutant_type.value].values.tolist()
 
     def get_step_values(self):
-        return self.single_level_data["step"].values
+        return self._single_level_data["step"].values
+
+    def get_valid_time_values(self):
+        return self._single_level_data["valid_time"].values
 
     def get_time_value(self) -> int:
-        return int(self.single_level_data["time"].values)
+        return int(self._single_level_data["time"].values)

--- a/air-quality-backend/src/etl/forecast/forecast_data.py
+++ b/air-quality-backend/src/etl/forecast/forecast_data.py
@@ -35,6 +35,9 @@ class ForecastData:
     def __init__(self, single_level_data: xr.Dataset, multi_level_data: xr.Dataset):
         self._single_level_data = convert_dataset(single_level_data)
         self._multi_level_data = convert_dataset(multi_level_data)
+        # Eager load datasets for quicker access
+        self._single_level_data.load()
+        self._multi_level_data.load()
 
     def _get_data_set(self, pollutant_type: PollutantType) -> xr.Dataset:
         if is_single_level(pollutant_type):

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
@@ -15,8 +15,8 @@ from .mock_forecast_data import (
 @pytest.mark.parametrize(
     "field, expected",
     [
-        ("city", ["Dublin", "Dublin"]),
-        ("city_location", {"coordinates": [0, -10], "type": "Point"}),
+        ("name", ["Dublin", "Dublin"]),
+        ("location", {"coordinates": [0, -10], "type": "Point"}),
         (
             "measurement_date",
             [datetime(2024, 4, 23, 0, 0), datetime(2024, 4, 24, 0, 0)],
@@ -25,7 +25,7 @@ from .mock_forecast_data import (
 )
 def test__transform__returns_correct_values(field, expected):
     input_data = ForecastData(single_level_data_set, multi_level_data_set)
-    results = transform(input_data, default_test_cities[0:1])
+    results = transform(input_data, default_test_cities[0])
     if isinstance(expected, list):
         assert list(map(lambda x: x[field], results)) == expected
     else:
@@ -41,8 +41,9 @@ def test__transform__returns_correctly_formatted_data():
         "value": {"type": "float"},
     }
     expected_document_schema = {
-        "city": {"type": "string", "allowed": ["Dublin", "London", "Paris"]},
-        "city_location": {
+        "name": {"type": "string", "allowed": ["Dublin"]},
+        "location_type": {"type": "string", "allowed": ["city"]},
+        "location": {
             "type": "dict",
             "schema": {
                 "coordinates": {
@@ -65,6 +66,6 @@ def test__transform__returns_correctly_formatted_data():
         "overall_aqi_level": expected_aqi_schema,
     }
     validator = Validator(expected_document_schema, require_all=True)
-    result = transform(input_data, default_test_cities)
+    result = transform(input_data, default_test_cities[0])
     for data in result:
         assert validator(data) is True, f"{validator.errors}"

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
@@ -3,59 +3,13 @@ from datetime import datetime
 import pytest
 from src.etl.forecast.forecast_adapter import (
     ForecastData,
-    convert_east_only_longitude_to_east_west,
-    find_value_for_city,
     transform,
 )
 from .mock_forecast_data import (
     single_level_data_set,
     multi_level_data_set,
     default_test_cities,
-    create_test_pollutant_data,
 )
-
-
-@pytest.mark.parametrize(
-    "longitude, expected",
-    [
-        (0.0, 0.0),
-        (179.6, 179.6),
-        (180.0, 180.0),
-        (180.4, -179.6),
-        (360.0, 0),
-        (359.6, -0.4),
-        (-0.1, -0.1),
-        (-180.0, -180.0),
-    ],
-)
-def test__convert_longitude_east_range(longitude: float, expected: float):
-    assert convert_east_only_longitude_to_east_west(longitude) == expected
-
-
-@pytest.mark.parametrize(
-    "latitude, longitude, expected",
-    [
-        (-10.0, -90.0, [1]),
-        (0, 0.0, [4]),
-        (10.0, 90.0, [10]),
-        (-5.0, -45.0, [2.25]),
-        (5.0, 90.0, [9]),
-        (8.75, 60.0, [9]),
-    ],
-)
-def test__find_value_for_city(latitude: float, longitude: float, expected):
-    #      -90  0  90
-    # -10    1  2   4
-    #   0    2  4   8
-    #  10    4  8  10
-    input_data = create_test_pollutant_data(
-        steps=[24],
-        latitudes=[-10, 0, 10],
-        longitudes=[0, 90, 270],
-        values=[2, 4, 1, 4, 8, 2, 8, 10, 4],
-    )
-    result = find_value_for_city(input_data, latitude, longitude)
-    assert (result == expected).all()
 
 
 @pytest.mark.parametrize(

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_dao_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_dao_test.py
@@ -16,7 +16,7 @@ def mock_open_dataset():
 
 
 def test_get_single_level_request_body():
-    request = get_single_level_request_body("2024-04-29")
+    request = get_single_level_request_body("2024-04-29", "00")
     assert request == {
         "date": "2024-04-29/2024-04-29",
         "type": "forecast",
@@ -62,7 +62,7 @@ def test_get_single_level_request_body():
 
 
 def test_get_multi_level_request_body():
-    request = get_multi_level_request_body("2024-04-29")
+    request = get_multi_level_request_body("2024-04-29", "00")
     assert request == {
         "date": "2024-04-29/2024-04-29",
         "type": "forecast",
@@ -113,23 +113,24 @@ def test_fetch_forecast_data_returns_forecast_data(mocker, mock_open_dataset):
     mocker.patch("cdsapi.Client", return_value=mock_cdsapi_client)
     mock_open_dataset.side_effect = [single_level_data_set, multi_level_data_set]
 
-    forecast_data = fetch_forecast_data(model_base_date=datetime.now())
+    date = datetime.strptime("2024-05-20", "%Y-%m-%d")
+    forecast_data = fetch_forecast_data(model_base_date=date)
 
     mock_open_dataset.assert_has_calls(
         [
             call(
-                "single_level.grib",
+                "single_level_2024-05-20_00.grib",
                 decode_times=False,
                 engine="cfgrib",
                 backend_kwargs={"indexpath": ""},
             ),
             call(
-                "multi_level.grib",
+                "multi_level_2024-05-20_00.grib",
                 decode_times=False,
                 engine="cfgrib",
                 backend_kwargs={"indexpath": ""},
             ),
         ]
     )
-    assert forecast_data.single_level_data == single_level_data_set
-    assert forecast_data.multi_level_data == multi_level_data_set
+    assert forecast_data._single_level_data == single_level_data_set
+    assert forecast_data._multi_level_data == multi_level_data_set

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_data_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_data_test.py
@@ -1,0 +1,60 @@
+import pytest
+import xarray
+from src.etl.air_quality_index.pollutant_type import PollutantType
+from src.etl.forecast.forecast_data import (
+    convert_east_only_longitude_to_east_west,
+    ForecastData,
+)
+from .mock_forecast_data import (
+    create_test_pollutant_data,
+)
+
+
+@pytest.mark.parametrize(
+    "longitude, expected",
+    [
+        (0.0, 0.0),
+        (179.6, 179.6),
+        (180.0, 180.0),
+        (180.4, -179.6),
+        (360.0, 0),
+        (359.6, -0.4),
+        (-0.1, -0.1),
+        (-180.0, -180.0),
+    ],
+)
+def test__convert_longitude_east_range(longitude: float, expected: float):
+    assert convert_east_only_longitude_to_east_west(longitude) == expected
+
+
+@pytest.mark.parametrize(
+    "latitude, longitude, expected",
+    [
+        (-10.0, -90.0, [1]),
+        (0, 0.0, [4]),
+        (10.0, 90.0, [10]),
+        (-5.0, -45.0, [2.25]),
+        (5.0, 90.0, [9]),
+        (8.75, 60.0, [9]),
+    ],
+)
+def test__get_pollutant_data_for_lat_long(latitude: float, longitude: float, expected):
+    #      -90  0  90
+    # -10    1  2   4
+    #   0    2  4   8
+    #  10    4  8  10
+    input_data = create_test_pollutant_data(
+        steps=[24],
+        latitudes=[-10, 0, 10],
+        longitudes=[0, 90, 270],
+        values=[2, 4, 1, 4, 8, 2, 8, 10, 4],
+    )
+    dataset = xarray.Dataset(
+        coords=dict(step=[24]),
+        data_vars=dict(no2=input_data),
+    )
+    forecast_data = ForecastData(dataset, dataset)
+    result = forecast_data.get_pollutant_data_for_lat_long(
+        latitude, longitude, PollutantType.NITROGEN_DIOXIDE
+    )
+    assert result == expected

--- a/air-quality-backend/tests/etl_tests/forecast/mock_forecast_data.py
+++ b/air-quality-backend/tests/etl_tests/forecast/mock_forecast_data.py
@@ -7,6 +7,7 @@ default_steps = [24, 48]
 default_latitudes = [-10, 0, 10]
 default_longitudes = [0, 10, 350]
 default_time = 1713744000
+default_valid_time = [default_time + (x * 60 * 60) for x in default_steps]
 default_test_cities = [
     create_test_city("Dublin", -10, 0),
     create_test_city("London", 0, 10),
@@ -149,11 +150,11 @@ pm10 = create_test_pollutant_data_with_defaults(
 
 
 single_level_data_set = xarray.Dataset(
-    coords=dict(time=default_time, step=default_steps),
+    coords=dict(time=default_time, step=default_steps, valid_time=default_valid_time),
     data_vars=dict(pm2p5=pm2p5, pm10=pm10),
 )
 
 multi_level_data_set = xarray.Dataset(
-    coords=dict(time=default_time, step=default_steps),
+    coords=dict(time=default_time, step=default_steps, valid_time=default_valid_time),
     data_vars=dict(no2=no2, go3=go3, so2=so2),
 )

--- a/air-quality-backend/tests/etl_tests/test_util.py
+++ b/air-quality-backend/tests/etl_tests/test_util.py
@@ -1,2 +1,2 @@
 def create_test_city(name: str, latitude: float, longitude: float):
-    return {"name": name, "latitude": latitude, "longitude": longitude}
+    return {"name": name, "latitude": latitude, "longitude": longitude, "type": "city"}

--- a/air-quality-backend/tools/add_cities_to_locations.py
+++ b/air-quality-backend/tools/add_cities_to_locations.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from src.database import get_collection
+from src.database.air_quality_dashboard_dao import get_collection
 
 df = pd.read_csv("CAMS_locations_V1.csv")
 df["type"] = "city"


### PR DESCRIPTION
## Description

Performance was particularly slow because xarray lazily loads data from a dataset. We then try to access each dataset for each city which without eagerly loading is quite slow.

By explicitly calling load, we use more memory but performance improves. Introducing threads also significantly improves the runtime.

 We now process all 153 in around 2 minutes instead of 10.

### Default
15 cities per minutes

### With eager load
25 cities per minute

### With eager load and thread pool
76 cities per minute

## Output
```
2024-05-20 17:07:46,450 - INFO - Finding data for 153 cities
2024-05-20 17:07:46,450 - INFO - Extracting pollutant forecast data
2024-05-20 17:07:46,462 - INFO - Loading data from CAMS to file single_level_2024-05-20_00.grib
2024-05-20 17:07:47,403 - INFO - Loading data from CAMS to file multi_level_2024-05-20_00.grib
2024-05-20 17:07:49,678 - INFO - Transforming forecast data
2024-05-20 17:09:00,256 - INFO - Persisting forecast data
2024-05-20 17:09:12,220 - INFO - 5049 documents upserted, 0 modified
```