### PR TITLE
Update forecast data model

### DIFF
--- a/air-quality-backend/liquibase/forecast_data.xml
+++ b/air-quality-backend/liquibase/forecast_data.xml
@@ -12,10 +12,10 @@
     <mongodb:createCollection collectionName="forecast_data"/>
     <mongodb:createIndex collectionName="forecast_data">
       <mongodb:keys>
-        { measurement_date: 1, name: 1}
+        { forecast_valid_time: 1, name: 1}
       </mongodb:keys>
       <mongodb:options>
-        {unique: true, name: "measurement_date_1_name_1"}
+        {unique: true, name: "forecast_valid_time_1_name_1"}
       </mongodb:options>
     </mongodb:createIndex>
     <mongodb:createIndex collectionName="forecast_data">

--- a/air-quality-backend/liquibase/forecast_data.xml
+++ b/air-quality-backend/liquibase/forecast_data.xml
@@ -12,10 +12,10 @@
     <mongodb:createCollection collectionName="forecast_data"/>
     <mongodb:createIndex collectionName="forecast_data">
       <mongodb:keys>
-        { forecast_valid_time: 1, name: 1}
+        { forecast_base_time: 1, forecast_valid_time: 1, location_type: 1, name: 1, source: 1 }
       </mongodb:keys>
       <mongodb:options>
-        {unique: true, name: "forecast_valid_time_1_name_1"}
+        {unique: true, name: "uniq_forecast_idx"}
       </mongodb:options>
     </mongodb:createIndex>
     <mongodb:createIndex collectionName="forecast_data">

--- a/air-quality-backend/src/database/air_quality_dashboard_dao.py
+++ b/air-quality-backend/src/database/air_quality_dashboard_dao.py
@@ -20,7 +20,10 @@ def _upsert_measurement_data(collection_name, data):
     update_operations = [
         (
             UpdateOne(
-                {"name": doc["name"], "measurement_date": doc["measurement_date"]},
+                {
+                    "name": doc["name"],
+                    "forecast_valid_time": doc["forecast_valid_time"],
+                },
                 [
                     {
                         "$set": {
@@ -65,7 +68,11 @@ def get_locations_by_type(location_type: str) -> list[AirQualityLocation]:
 
 
 def delete_data_before(measurement_time: datetime):
-    collections = [get_collection("forecast_data"), get_collection("in_situ_data")]
-    for collection in collections:
-        result = collection.delete_many({"measurement_date": {"$lt": measurement_time}})
-        logging.info(f"Deleted {result.deleted_count} documents from {collection.name}")
+    result = get_collection("forecast_data").delete_many(
+        {"forecast_valid_time": {"$lt": measurement_time}}
+    )
+    logging.info(f"Deleted {result.deleted_count} documents from forecast_data")
+    result = get_collection("in_situ_data").delete_many(
+        {"measurement_date": {"$lt": measurement_time}}
+    )
+    logging.info(f"Deleted {result.deleted_count} documents from in_situ_data")

--- a/air-quality-backend/src/etl/forecast/forecast_adapter.py
+++ b/air-quality-backend/src/etl/forecast/forecast_adapter.py
@@ -93,6 +93,7 @@ def transform(forecast_data: ForecastData, location: AirQualityLocation) -> list
             "forecast_valid_time": measurement_date,
             "forecast_range": int(step_values[i]),
             "overall_aqi_level": overall_aqi_value,
+            "source": "cams-production",
             **pollutant_data,
         }
 

--- a/air-quality-backend/src/etl/forecast/forecast_adapter.py
+++ b/air-quality-backend/src/etl/forecast/forecast_adapter.py
@@ -61,6 +61,7 @@ def _get_overall_aqi_value_for_slice(
 
 def transform(forecast_data: ForecastData, location: AirQualityLocation) -> list:
     valid_time_values = forecast_data.get_valid_time_values()
+    model_base_time = datetime.utcfromtimestamp(forecast_data.get_time_value())
     pollutant_forecast_for_location = []
     location_name = location["name"]
     location_type = location["type"]
@@ -87,6 +88,7 @@ def transform(forecast_data: ForecastData, location: AirQualityLocation) -> list
                 "type": "Point",
                 "coordinates": [location["longitude"], location["latitude"]],
             },
+            "forecast_base_time": model_base_time,
             "measurement_date": measurement_date,
             "overall_aqi_level": overall_aqi_value,
             **pollutant_data,

--- a/air-quality-backend/src/etl/forecast/forecast_adapter.py
+++ b/air-quality-backend/src/etl/forecast/forecast_adapter.py
@@ -61,6 +61,7 @@ def _get_overall_aqi_value_for_slice(
 
 def transform(forecast_data: ForecastData, location: AirQualityLocation) -> list:
     valid_time_values = forecast_data.get_valid_time_values()
+    step_values = forecast_data.get_step_values()
     model_base_time = datetime.utcfromtimestamp(forecast_data.get_time_value())
     pollutant_forecast_for_location = []
     location_name = location["name"]
@@ -90,6 +91,7 @@ def transform(forecast_data: ForecastData, location: AirQualityLocation) -> list
             },
             "forecast_base_time": model_base_time,
             "forecast_valid_time": measurement_date,
+            "forecast_range": int(step_values[i]),
             "overall_aqi_level": overall_aqi_value,
             **pollutant_data,
         }

--- a/air-quality-backend/src/etl/forecast/forecast_adapter.py
+++ b/air-quality-backend/src/etl/forecast/forecast_adapter.py
@@ -89,7 +89,7 @@ def transform(forecast_data: ForecastData, location: AirQualityLocation) -> list
                 "coordinates": [location["longitude"], location["latitude"]],
             },
             "forecast_base_time": model_base_time,
-            "measurement_date": measurement_date,
+            "forecast_valid_time": measurement_date,
             "overall_aqi_level": overall_aqi_value,
             **pollutant_data,
         }

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
@@ -19,7 +19,7 @@ from .mock_forecast_data import (
         ("name", ["Dublin", "Dublin"]),
         ("location", {"coordinates": [0, -10], "type": "Point"}),
         (
-            "measurement_date",
+            "forecast_valid_time",
             [datetime(2024, 4, 23, 0, 0), datetime(2024, 4, 24, 0, 0)],
         ),
         ("forecast_base_time", datetime.utcfromtimestamp(default_time)),
@@ -59,7 +59,7 @@ def test__transform__returns_correctly_formatted_data():
                 },
             },
         },
-        "measurement_date": {"type": "datetime"},
+        "forecast_valid_time": {"type": "datetime"},
         "forecast_base_time": {"type": "datetime"},
         "no2": {"type": "dict", "schema": expected_pollutant_schema},
         "o3": {"type": "dict", "schema": expected_pollutant_schema},

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
@@ -9,6 +9,7 @@ from .mock_forecast_data import (
     single_level_data_set,
     multi_level_data_set,
     default_test_cities,
+    default_time,
 )
 
 
@@ -21,6 +22,7 @@ from .mock_forecast_data import (
             "measurement_date",
             [datetime(2024, 4, 23, 0, 0), datetime(2024, 4, 24, 0, 0)],
         ),
+        ("forecast_base_time", datetime.utcfromtimestamp(default_time)),
     ],
 )
 def test__transform__returns_correct_values(field, expected):
@@ -58,6 +60,7 @@ def test__transform__returns_correctly_formatted_data():
             },
         },
         "measurement_date": {"type": "datetime"},
+        "forecast_base_time": {"type": "datetime"},
         "no2": {"type": "dict", "schema": expected_pollutant_schema},
         "o3": {"type": "dict", "schema": expected_pollutant_schema},
         "pm10": {"type": "dict", "schema": expected_pollutant_schema},

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
@@ -24,6 +24,7 @@ from .mock_forecast_data import (
         ),
         ("forecast_base_time", datetime.utcfromtimestamp(default_time)),
         ("forecast_range", [24, 48]),
+        ("source", "cams-production"),
     ],
 )
 def test__transform__returns_correct_values(field, expected):
@@ -44,7 +45,7 @@ def test__transform__returns_correctly_formatted_data():
         "value": {"type": "float"},
     }
     expected_document_schema = {
-        "name": {"type": "string", "allowed": ["Dublin"]},
+        "name": {"type": "string"},
         "location_type": {"type": "string", "allowed": ["city"]},
         "location": {
             "type": "dict",
@@ -69,6 +70,7 @@ def test__transform__returns_correctly_formatted_data():
         "pm2_5": {"type": "dict", "schema": expected_pollutant_schema},
         "so2": {"type": "dict", "schema": expected_pollutant_schema},
         "overall_aqi_level": expected_aqi_schema,
+        "source": {"type": "string", "allowed": ["cams-production"]},
     }
     validator = Validator(expected_document_schema, require_all=True)
     result = transform(input_data, default_test_cities[0])

--- a/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl_tests/forecast/forecast_adapter_test.py
@@ -23,6 +23,7 @@ from .mock_forecast_data import (
             [datetime(2024, 4, 23, 0, 0), datetime(2024, 4, 24, 0, 0)],
         ),
         ("forecast_base_time", datetime.utcfromtimestamp(default_time)),
+        ("forecast_range", [24, 48]),
     ],
 )
 def test__transform__returns_correct_values(field, expected):
@@ -61,6 +62,7 @@ def test__transform__returns_correctly_formatted_data():
         },
         "forecast_valid_time": {"type": "datetime"},
         "forecast_base_time": {"type": "datetime"},
+        "forecast_range": {"type": "integer"},
         "no2": {"type": "dict", "schema": expected_pollutant_schema},
         "o3": {"type": "dict", "schema": expected_pollutant_schema},
         "pm10": {"type": "dict", "schema": expected_pollutant_schema},


### PR DESCRIPTION
## Changes

- Start storing forecast_base_time and forecast_range (steps)
- Rename measurment_date to forecast_valid_time
- Add source property which is for now always 'cams-production'
- Unique index on mongodb changed

For #19 

