### PR TITLE
select pollutant before interpolation to save time

### DIFF
--- a/air-quality-backend/src/etl/forecast/forecast_data.py
+++ b/air-quality-backend/src/etl/forecast/forecast_data.py
@@ -53,11 +53,11 @@ class ForecastData:
         :return: values for pollutant at lat/long
         """
         dataset = self._get_data_set(pollutant_type)
-        return dataset.interp(
+        return dataset[pollutant_type.value].interp(
             latitude=latitude,
             longitude=longitude,
             method="linear",
-        )[pollutant_type.value].values.tolist()
+        ).values.tolist()
 
     def get_step_values(self):
         return self._single_level_data["step"].values


### PR DESCRIPTION
Quick change to select the pollutant before the interpolation. The order of calling methods in xarray does matter, so currently all 2 (or 3 for multilevel) pollutants get interpolated and you just select one afterwards. This means you do a lot of unnecessary interpolations. Speed improvement for transform task should therefore be around factor 2-3.