### PR TITLE
Improve performance of forecast ETL by reducing interpolation calls

### DIFF
--- a/air-quality-backend/.flake8
+++ b/air-quality-backend/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+ignore = E203

--- a/air-quality-backend/scripts/run_forecast_etl.py
+++ b/air-quality-backend/scripts/run_forecast_etl.py
@@ -1,6 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor
 from dotenv import load_dotenv
-from itertools import chain
 import logging
 from logging import config
 from air_quality.database.locations import get_locations_by_type
@@ -21,12 +19,7 @@ def main():
     extracted_forecast_data = fetch_forecast_data()
 
     logging.info("Transforming forecast data")
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = [
-            executor.submit(transform, extracted_forecast_data, city) for city in cities
-        ]
-        results = [future.result() for future in futures]
-    transformed_forecast_data = list(chain.from_iterable(results))
+    transformed_forecast_data = transform(extracted_forecast_data, cities)
 
     logging.info("Persisting forecast data")
     insert_data(transformed_forecast_data)

--- a/air-quality-backend/src/air_quality/database/mongo_db_operations.py
+++ b/air-quality-backend/src/air_quality/database/mongo_db_operations.py
@@ -14,6 +14,7 @@ def get_collection(name: str):
 def upsert_data(collection_name: str, keys: list[str], data):
     if len(data) == 0:
         return
+    logging.info(f"Persisting {len(data)} documents")
     collection = get_collection(collection_name)
     now = datetime.utcnow()
 

--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_adapter.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_adapter.py
@@ -57,7 +57,6 @@ def transform(forecast_data: ForecastData, locations: list[AirQualityLocation]) 
     pollutant_data_with_location = forecast_data.get_pollutant_data_for_locations(
         locations, list(PollutantType)
     )
-    logging.debug(f"Pollutant data with location: {len(pollutant_data_with_location)}")
 
     valid_time_values = forecast_data.get_valid_time_values()
     step_values = forecast_data.get_step_values()

--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_adapter.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_adapter.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 import logging
 from typing import TypedDict
@@ -60,7 +60,9 @@ def transform(forecast_data: ForecastData, locations: list[AirQualityLocation]) 
 
     valid_time_values = forecast_data.get_valid_time_values()
     step_values = forecast_data.get_step_values()
-    model_base_time = datetime.utcfromtimestamp(forecast_data.get_time_value())
+    model_base_time = datetime.fromtimestamp(
+        forecast_data.get_time_value(), timezone.utc
+    )
     pollutant_forecast_for_location = []
 
     for location, data_by_pollutant in pollutant_data_with_location:
@@ -74,7 +76,9 @@ def transform(forecast_data: ForecastData, locations: list[AirQualityLocation]) 
 
         for i in range(0, step_values.size):
             measurement_timestamp = valid_time_values[i]
-            measurement_date = datetime.utcfromtimestamp(measurement_timestamp)
+            measurement_date = datetime.fromtimestamp(
+                measurement_timestamp, timezone.utc
+            )
             overall_aqi_value = _get_overall_aqi_value_for_step(
                 forecast_data_by_type, i
             )

--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_adapter.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_adapter.py
@@ -13,34 +13,36 @@ class PollutantData(TypedDict):
     aqi_values: list[int]
 
 
-def _get_pollutant_values_by_type(
-    forecast_data: ForecastData, location: AirQualityLocation
-) -> dict[PollutantType:PollutantData]:
-    forecast_data_by_type: dict[PollutantType:PollutantData] = {}
-    for pollutant_type in PollutantType:
-        pollutant_forecast_values = forecast_data.get_pollutant_data_for_lat_long(
-            location["latitude"], location["longitude"], pollutant_type
-        )
-        pollutant_forecast_values_ug_m3 = [
-            float(Decimal(str(x)) * Decimal(10**9)) for x in pollutant_forecast_values
-        ]
-        forecast_data_by_type[pollutant_type] = {
-            "values_ug_m3": pollutant_forecast_values_ug_m3,
-            "aqi_values": list(
-                map(
-                    lambda x: aqi_calculator.get_pollutant_index_level(
-                        x, pollutant_type
-                    ),
-                    pollutant_forecast_values_ug_m3,
-                )
-            ),
-        }
-    return forecast_data_by_type
+def _convert_pollutant_values(pollutant_type: PollutantType, raw_values: list[float]):
+    """
+    Convert pollutant values to appropriate units and add aqi_values
+    :param pollutant_type:
+    :param raw_values:
+    :return:
+    """
+    pollutant_forecast_values_ug_m3 = [
+        float(Decimal(str(x)) * Decimal(10**9)) for x in raw_values
+    ]
+    return {
+        "values_ug_m3": pollutant_forecast_values_ug_m3,
+        "aqi_values": list(
+            map(
+                lambda x: aqi_calculator.get_pollutant_index_level(x, pollutant_type),
+                pollutant_forecast_values_ug_m3,
+            )
+        ),
+    }
 
 
-def _get_overall_aqi_value_for_slice(
+def _get_overall_aqi_value_for_step(
     location_forecast_data_by_type: dict[PollutantType:PollutantData], index: int
 ) -> int:
+    """
+    Calculate overall AQI value for pollutants at single forecast_valid_time (step)
+    :param location_forecast_data_by_type:
+    :param index:
+    :return: overall_aqi_value
+    """
     return aqi_calculator.get_overall_aqi_level(
         list(
             map(
@@ -51,44 +53,54 @@ def _get_overall_aqi_value_for_slice(
     )
 
 
-def transform(forecast_data: ForecastData, location: AirQualityLocation) -> list:
+def transform(forecast_data: ForecastData, locations: list[AirQualityLocation]) -> list:
+    pollutant_data_with_location = forecast_data.get_pollutant_data_for_locations(
+        locations, list(PollutantType)
+    )
+    logging.debug(f"Pollutant data with location: {len(pollutant_data_with_location)}")
+
     valid_time_values = forecast_data.get_valid_time_values()
     step_values = forecast_data.get_step_values()
     model_base_time = datetime.utcfromtimestamp(forecast_data.get_time_value())
     pollutant_forecast_for_location = []
-    location_name = location["name"]
-    location_type = location["type"]
-    logging.debug(f"Processing location: {location_name} ({location['type']})")
-    forecast_data_by_type = _get_pollutant_values_by_type(forecast_data, location)
 
-    for i in range(0, valid_time_values.size):
-        measurement_timestamp = valid_time_values[i]
-        measurement_date = datetime.utcfromtimestamp(measurement_timestamp)
-        overall_aqi_value = _get_overall_aqi_value_for_slice(forecast_data_by_type, i)
-
-        pollutant_data = {}
-        for pollutant_type in PollutantType:
-            forecast_data = forecast_data_by_type[pollutant_type]
-            pollutant_data[pollutant_type.value] = {
-                "aqi_level": forecast_data["aqi_values"][i],
-                "value": forecast_data["values_ug_m3"][i],
-            }
-
-        document = {
-            "name": location_name,
-            "location_type": location_type,
-            "location": {
-                "type": "Point",
-                "coordinates": [location["longitude"], location["latitude"]],
-            },
-            "forecast_base_time": model_base_time,
-            "forecast_valid_time": measurement_date,
-            "forecast_range": int(step_values[i]),
-            "overall_aqi_level": overall_aqi_value,
-            "source": "cams-production",
-            **pollutant_data,
+    for location, data_by_pollutant in pollutant_data_with_location:
+        location_name = location["name"]
+        location_type = location["type"]
+        logging.debug(f"Processing location: {location_name} ({location['type']})")
+        forecast_data_by_type = {
+            pollutant_type: _convert_pollutant_values(pollutant_type, data)
+            for pollutant_type, data in data_by_pollutant.items()
         }
 
-        pollutant_forecast_for_location.append(document)
+        for i in range(0, step_values.size):
+            measurement_timestamp = valid_time_values[i]
+            measurement_date = datetime.utcfromtimestamp(measurement_timestamp)
+            overall_aqi_value = _get_overall_aqi_value_for_step(
+                forecast_data_by_type, i
+            )
 
+            pollutant_data = {
+                pollutant_type.value: {
+                    "aqi_level": forecast_data_by_type[pollutant_type]["aqi_values"][i],
+                    "value": forecast_data_by_type[pollutant_type]["values_ug_m3"][i],
+                }
+                for pollutant_type in PollutantType
+            }
+
+            document = {
+                "name": location_name,
+                "location_type": location_type,
+                "location": {
+                    "type": "Point",
+                    "coordinates": [location["longitude"], location["latitude"]],
+                },
+                "forecast_base_time": model_base_time,
+                "forecast_valid_time": measurement_date,
+                "forecast_range": int(step_values[i]),
+                "overall_aqi_level": overall_aqi_value,
+                "source": "cams-production",
+                **pollutant_data,
+            }
+            pollutant_forecast_for_location.append(document)
     return pollutant_forecast_for_location

--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_data.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_data.py
@@ -103,7 +103,8 @@ class ForecastData:
         interpolated_data_by_pollutant_type = {}
         for pollutant_type in pollutant_types:
             dataset = self._get_data_set(pollutant_type)
-            # Interpolation is called n times, where n = len(pollutant_types) irrespective of len(locations)
+            # Interpolation is called n times, where n = len(pollutant_types),
+            # irrespective of len(locations)
             interpolated_data = dataset[pollutant_data_map[pollutant_type]].interp(
                 latitude=xr.DataArray(latitudes, dims="points"),
                 longitude=xr.DataArray(longitudes, dims="points"),

--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_data.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_data.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 import logging
 import xarray as xr
+from air_quality.database.locations import AirQualityLocation
 from air_quality.etl.air_quality_index.pollutant_type import (
     PollutantType,
     is_single_level,
@@ -83,27 +84,46 @@ class ForecastData:
         else:
             return self._multi_level_data
 
-    def get_pollutant_data_for_lat_long(
-        self, latitude: float, longitude: float, pollutant_type: PollutantType
-    ) -> list[float]:
+    def get_pollutant_data_for_locations(
+        self, locations: list[AirQualityLocation], pollutant_types: list[PollutantType]
+    ) -> list[tuple[AirQualityLocation, dict[PollutantType : list[float]]]]:
         """
-        Get forecasted air pollutant values (kgm3) for a given lat/long
-        and pollutant using bilinear interpolation
-        :param latitude:
-        :param longitude:
-        :param pollutant_type:
+        Get forecasted air pollutant values for given locations
+        and pollutants using bilinear interpolation
+        :param locations:
+        :param pollutant_types:
         :return: values for pollutant at lat/long
         """
-        dataset = self._get_data_set(pollutant_type)
-        return (
-            dataset[pollutant_data_map[pollutant_type]]
-            .interp(
-                latitude=latitude,
-                longitude=longitude,
+        latitudes = []
+        longitudes = []
+        for location in locations:
+            latitudes.append(location["latitude"])
+            longitudes.append(location["longitude"])
+
+        interpolated_data_by_pollutant_type = {}
+        for pollutant_type in pollutant_types:
+            dataset = self._get_data_set(pollutant_type)
+            # Interpolation is called n times, where n = len(pollutant_types) irrespective of len(locations)
+            interpolated_data = dataset[pollutant_data_map[pollutant_type]].interp(
+                latitude=xr.DataArray(latitudes, dims="points"),
+                longitude=xr.DataArray(longitudes, dims="points"),
                 method="linear",
             )
-            .values.tolist()
-        )
+            interpolated_data_by_pollutant_type[pollutant_type] = interpolated_data
+
+        location_pollutant_tuples = []
+        for i, location in enumerate(locations):
+            location_pollutant_data = {}
+            for (
+                pollutant_type,
+                interpolated_data,
+            ) in interpolated_data_by_pollutant_type.items():
+                pollutant_forecast_values = interpolated_data.isel(points=i)
+                location_pollutant_data[pollutant_type] = (
+                    pollutant_forecast_values.values.tolist()
+                )
+            location_pollutant_tuples.append((location, location_pollutant_data))
+        return location_pollutant_tuples
 
     def get_step_values(self):
         return self._single_level_data["step"].values

--- a/air-quality-backend/src/air_quality/etl/in_situ/aqicn_dao.py
+++ b/air-quality-backend/src/air_quality/etl/in_situ/aqicn_dao.py
@@ -8,9 +8,7 @@ base_url = "https://api.waqi.info/feed"
 
 
 def fetch_in_situ_measurement(lat: float, long: float):
-    query_params = {
-        "token": os.environ.get("AQI_CN_API_TOKEN")
-    }
+    query_params = {"token": os.environ.get("AQI_CN_API_TOKEN")}
     url = f"{base_url}/geo:{lat};{long}?{urlencode(query_params, doseq=True)}"
     logging.info(f"Calling aqicn geo feed: {url}")
     response_json = requests.get(url).json()

--- a/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
@@ -1,5 +1,5 @@
 from cerberus import Validator
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 from air_quality.etl.forecast.forecast_adapter import (
     ForecastData,
@@ -35,7 +35,7 @@ from .mock_forecast_data import (
                 datetime(2024, 4, 24, 0, 0),
             ],
         ),
-        ("forecast_base_time", datetime.utcfromtimestamp(default_time)),
+        ("forecast_base_time", datetime.fromtimestamp(default_time, timezone.utc)),
         ("forecast_range", [24, 48, 24, 48]),
         ("source", "cams-production"),
     ],

--- a/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
@@ -16,20 +16,34 @@ from .mock_forecast_data import (
 @pytest.mark.parametrize(
     "field, expected",
     [
-        ("name", ["Dublin", "Dublin"]),
-        ("location", {"coordinates": [0, -10], "type": "Point"}),
+        ("name", ["Dublin", "Dublin", "London", "London"]),
+        (
+            "location",
+            [
+                {"coordinates": [0, -10], "type": "Point"},
+                {"coordinates": [0, -10], "type": "Point"},
+                {"coordinates": [10, 0], "type": "Point"},
+                {"coordinates": [10, 0], "type": "Point"},
+            ],
+        ),
         (
             "forecast_valid_time",
-            [datetime(2024, 4, 23, 0, 0), datetime(2024, 4, 24, 0, 0)],
+            [
+                datetime(2024, 4, 23, 0, 0),
+                datetime(2024, 4, 24, 0, 0),
+                datetime(2024, 4, 23, 0, 0),
+                datetime(2024, 4, 24, 0, 0),
+            ],
         ),
         ("forecast_base_time", datetime.utcfromtimestamp(default_time)),
-        ("forecast_range", [24, 48]),
+        ("forecast_range", [24, 48, 24, 48]),
         ("source", "cams-production"),
     ],
 )
 def test__transform__returns_correct_values(field, expected):
     input_data = ForecastData(single_level_data_set, multi_level_data_set)
-    results = transform(input_data, default_test_cities[0:1])
+    dublin_and_london = default_test_cities[0:2]
+    results = transform(input_data, dublin_and_london)
     if isinstance(expected, list):
         assert list(map(lambda x: x[field], results)) == expected
     else:

--- a/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
@@ -29,10 +29,10 @@ from .mock_forecast_data import (
         (
             "forecast_valid_time",
             [
-                datetime(2024, 4, 23, 0, 0),
-                datetime(2024, 4, 24, 0, 0),
-                datetime(2024, 4, 23, 0, 0),
-                datetime(2024, 4, 24, 0, 0),
+                datetime(2024, 4, 23, 0, 0, tzinfo=timezone.utc),
+                datetime(2024, 4, 24, 0, 0, tzinfo=timezone.utc),
+                datetime(2024, 4, 23, 0, 0, tzinfo=timezone.utc),
+                datetime(2024, 4, 24, 0, 0, tzinfo=timezone.utc),
             ],
         ),
         ("forecast_base_time", datetime.fromtimestamp(default_time, timezone.utc)),

--- a/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
+++ b/air-quality-backend/tests/etl/forecast/forecast_adapter_test.py
@@ -29,7 +29,7 @@ from .mock_forecast_data import (
 )
 def test__transform__returns_correct_values(field, expected):
     input_data = ForecastData(single_level_data_set, multi_level_data_set)
-    results = transform(input_data, default_test_cities[0])
+    results = transform(input_data, default_test_cities[0:1])
     if isinstance(expected, list):
         assert list(map(lambda x: x[field], results)) == expected
     else:
@@ -73,6 +73,6 @@ def test__transform__returns_correctly_formatted_data():
         "source": {"type": "string", "allowed": ["cams-production"]},
     }
     validator = Validator(expected_document_schema, require_all=True)
-    result = transform(input_data, default_test_cities[0])
+    result = transform(input_data, default_test_cities[0:1])
     for data in result:
         assert validator(data) is True, f"{validator.errors}"

--- a/air-quality-backend/tests/etl/forecast/forecast_data_test.py
+++ b/air-quality-backend/tests/etl/forecast/forecast_data_test.py
@@ -28,17 +28,18 @@ def test__convert_longitude_east_range(longitude: float, expected: float):
 
 
 @pytest.mark.parametrize(
-    "latitude, longitude, expected",
+    "coordinates, expected",
     [
-        (-10.0, -90.0, [1]),
-        (0, 0.0, [4]),
-        (10.0, 90.0, [10]),
-        (-5.0, -45.0, [2.25]),
-        (5.0, 90.0, [9]),
-        (8.75, 60.0, [9]),
+        ([(-10.0, -90.0)], [1]),
+        ([(0, 0.0)], [4]),
+        ([(10.0, 90.0)], [10]),
+        ([(-5.0, -45.0)], [2.25]),
+        ([(5.0, 90.0), (8.75, 60.0)], [9]),  # Multiple locations
     ],
 )
-def test__get_pollutant_data_for_locations(latitude: float, longitude: float, expected):
+def test__get_pollutant_data_for_locations__interpolates_correctly(
+    coordinates, expected
+):
     #      -90  0  90
     # -10    1  2   4
     #   0    2  4   8
@@ -49,13 +50,13 @@ def test__get_pollutant_data_for_locations(latitude: float, longitude: float, ex
         longitudes=[0, 90, 270],
         values=[2, 4, 1, 4, 8, 2, 8, 10, 4],
     )
-    sp = create_test_pollutant_data(
+    surface_pressure = create_test_pollutant_data(
         steps=[24],
         latitudes=[-10, 0, 10],
         longitudes=[0, 90, 270],
         values=[1, 1, 1, 1, 1, 1, 1, 1, 1],
     )
-    t = create_test_pollutant_data(
+    temperature = create_test_pollutant_data(
         steps=[24],
         latitudes=[-10, 0, 10],
         longitudes=[0, 90, 270],
@@ -63,21 +64,30 @@ def test__get_pollutant_data_for_locations(latitude: float, longitude: float, ex
     )
     single_level = xarray.Dataset(
         coords=dict(step=[24]),
-        data_vars=dict(pm2p5=input_data, sp=sp),
+        data_vars=dict(pm2p5=input_data, pm10=input_data, sp=surface_pressure),
     )
     multi_level = xarray.Dataset(
         coords=dict(step=[24]),
-        data_vars=dict(no2=input_data, t=t),
+        data_vars=dict(no2=input_data, so2=input_data, go3=input_data, t=temperature),
     )
     forecast_data = ForecastData(single_level, multi_level)
-    location = {
-        "name": "test",
-        "type": "test",
-        "latitude": latitude,
-        "longitude": longitude,
-    }
+    locations = [
+        {
+            "name": "test",
+            "type": "test",
+            "latitude": lat_long[0],
+            "longitude": lat_long[1],
+        }
+        for lat_long in coordinates
+    ]
+
     result = forecast_data.get_pollutant_data_for_locations(
-        [location],
-        [PollutantType.NITROGEN_DIOXIDE],
+        locations,
+        list(PollutantType),
     )
-    assert result == [(location, {PollutantType.NITROGEN_DIOXIDE: expected})]
+
+    expected_results = [
+        (location, {pollutant_type: expected for pollutant_type in PollutantType})
+        for location in locations
+    ]
+    assert result == expected_results

--- a/air-quality-backend/tests/etl/forecast/forecast_data_test.py
+++ b/air-quality-backend/tests/etl/forecast/forecast_data_test.py
@@ -38,7 +38,7 @@ def test__convert_longitude_east_range(longitude: float, expected: float):
         (8.75, 60.0, [9]),
     ],
 )
-def test__get_pollutant_data_for_lat_long(latitude: float, longitude: float, expected):
+def test__get_pollutant_data_for_locations(latitude: float, longitude: float, expected):
     #      -90  0  90
     # -10    1  2   4
     #   0    2  4   8
@@ -70,7 +70,14 @@ def test__get_pollutant_data_for_lat_long(latitude: float, longitude: float, exp
         data_vars=dict(no2=input_data, t=t),
     )
     forecast_data = ForecastData(single_level, multi_level)
-    result = forecast_data.get_pollutant_data_for_lat_long(
-        latitude, longitude, PollutantType.NITROGEN_DIOXIDE
+    location = {
+        "name": "test",
+        "type": "test",
+        "latitude": latitude,
+        "longitude": longitude,
+    }
+    result = forecast_data.get_pollutant_data_for_locations(
+        [location],
+        [PollutantType.NITROGEN_DIOXIDE],
     )
-    assert result == expected
+    assert result == [(location, {PollutantType.NITROGEN_DIOXIDE: expected})]


### PR DESCRIPTION
## Description
Rather than calling the interpolation function 5 * 153 times (for every pollutant and location combination) we reduce the call to 5 times (once per pollutant) by passing in the full array of 153 coordinate pairings in each call which significantly improves performance

## Changes
- Restructuring of code to allow calling of interpolation function with all locations
- Removed threadpool as no longer necessary

### Before
```
...
2024-05-29 12:03:46,766 - INFO - Transforming forecast data
2024-05-29 12:04:20,785 - INFO - Persisting forecast data
```
duration = ~34 seconds

### After
```
...
2024-05-29 12:21:30,513 - INFO - Transforming forecast data
2024-05-29 12:21:32,723 - INFO - Persisting forecast data
```
duration = ~2 seconds