### PR TITLE
Ignore linebreak before binary operator

### DIFF
--- a/air-quality-backend/.flake8
+++ b/air-quality-backend/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 88
-ignore = E203
+ignore = E203, W503


### PR DESCRIPTION
Remove warnings for flake8 W503 - "line break before binary operator". This was conflicting with the rules of black which would auto-format to break a line before the binary operator.

![image](https://github.com/ECMWFCode4Earth/vAirify/assets/11511477/813394e6-5e41-4789-ae91-78f143987aaf)
