### PR TITLE
ETL github action workflows

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy
+
 on:
   [workflow_dispatch]
 
@@ -26,12 +27,12 @@ jobs:
       - name: activate docker
         run: |  
           ssh ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd /usr/config && \\
-            sudo docker container stop etl-pipeline || true && \\
-            sudo docker rm etl-pipeline || true && \\
-            sudo docker pull ghcr.io/${{ github.repository }}/etl:latest && \\
-            sudo docker run -name etl-pipeline --env-file .env ghcr.io/${{ github.repository }}/etl:latest && \\
+            sudo docker container stop etl-forecast || true && \\
+            sudo docker rm etl-forecast || true && \\
+            sudo docker pull ghcr.io/${{ github.repository }}/etl-forecast:latest && \\
+            sudo docker run --name etl-forecast --env-file .env ghcr.io/${{ github.repository }}/etl-forecast:latest && \\
             exit"
       - name: clean up
         run: |
           rm -rf ~/.ssh
-
+          

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+on:
+  [workflow_dispatch]
+
+jobs:
+  deploy:
+    name: deploy image
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: install ssh keys
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ vars.SSH_HOST }} > ~/.ssh/known_hosts
+      - name: create .env
+        run: |
+          ssh ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd /usr/config && \\
+            echo MONGO_DB_URI=${{ secrets.MONGO_URI }} | sudo tee .env && \\
+            echo MONGO_DB_NAME=${{ secrets.MONGO_DB_NAME }} | sudo tee -a .env && \\
+            echo OPEN_AQ_API_KEY=${{ secrets.OPENAQ_KEY }} | sudo tee -a .env && \\
+            echo CDSAPI_URL=${{ secrets.CDSAPI_URL }} | sudo tee -a .env && \\
+            echo CDSAPI_KEY=${{ secrets.CDSAPI_KEY }} | sudo tee -a .env && \\
+            exit"
+      - name: activate docker
+        run: |  
+          ssh ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd /usr/config && \\
+            sudo docker pull ghcr.io/${{ github.repository }}/etl:latest && \\
+            sudo docker run --env-file .env ghcr.io/${{ github.repository }}/etl:latest && \\
+            exit"
+      - name: clean up
+        run: |
+          rm -rf ~/.ssh
+

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -26,8 +26,10 @@ jobs:
       - name: activate docker
         run: |  
           ssh ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd /usr/config && \\
+            sudo docker container stop etl-pipeline || true && \\
+            sudo docker rm etl-pipeline || true && \\
             sudo docker pull ghcr.io/${{ github.repository }}/etl:latest && \\
-            sudo docker run --env-file .env ghcr.io/${{ github.repository }}/etl:latest && \\
+            sudo docker run -name etl-pipeline --env-file .env ghcr.io/${{ github.repository }}/etl:latest && \\
             exit"
       - name: clean up
         run: |

--- a/.github/workflows/etl-docker-build.yml
+++ b/.github/workflows/etl-docker-build.yml
@@ -1,0 +1,23 @@
+name: Build and publish ETL docker image
+on:
+  [workflow_dispatch]
+
+jobs:
+  publish_image:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: read
+        packages: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: login
+        run: |
+          docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN}} ghcr.io
+      - name: build
+        run: |
+          cd air-quality-backend
+          docker build . -t ghcr.io/${{ github.repository }}/etl:latest -f Dockerfile.cron
+      - name: publish
+        run: |
+          docker push ghcr.io/${{ github.repository }}/etl:latest

--- a/.github/workflows/etl-docker-build.yml
+++ b/.github/workflows/etl-docker-build.yml
@@ -1,4 +1,5 @@
-name: Build and publish ETL docker image
+name: Build and publish ETL docker images
+
 on:
   [workflow_dispatch]
 
@@ -17,7 +18,7 @@ jobs:
       - name: build
         run: |
           cd air-quality-backend
-          docker build . -t ghcr.io/${{ github.repository }}/etl:latest -f Dockerfile.cron
+          docker build . -t ghcr.io/${{ github.repository }}/etl-forecast:latest -f Dockerfile.forecast.cron
       - name: publish
         run: |
-          docker push ghcr.io/${{ github.repository }}/etl:latest
+          docker push ghcr.io/${{ github.repository }}/etl-forecast:latest

--- a/air-quality-backend/.dockerignore
+++ b/air-quality-backend/.dockerignore
@@ -1,8 +1,0 @@
-.env
-
-liquibase
-docs
-tests
-system_tests
-
-*.grib

--- a/air-quality-backend/Dockerfile.forecast
+++ b/air-quality-backend/Dockerfile.forecast
@@ -1,11 +1,18 @@
 FROM continuumio/miniconda3
 
 WORKDIR /usr/src/app
-COPY ./ ./
-RUN conda env create -f conda/environment.yml
+COPY conda/environment.yml .
+RUN conda env create -f environment.yml
 
 SHELL ["conda", "run", "-n", "air-quality-backend", "/bin/bash", "-c"]
 
+COPY pyproject.toml .
 RUN poetry install
+
+COPY src/ ./src
+COPY scripts/run_forecast_etl.py ./scripts/run_forecast_etl.py
+COPY README.md logging.ini ./
+
+RUN poetry install 
 
 ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "air-quality-backend", "python", "scripts/run_forecast_etl.py"]

--- a/air-quality-backend/Dockerfile.forecast.cron
+++ b/air-quality-backend/Dockerfile.forecast.cron
@@ -13,12 +13,21 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
  && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
  && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
-WORKDIR /usr/src/app
-COPY ./ ./
-RUN conda env create -f conda/environment.yml
+ WORKDIR /usr/src/app
+ COPY conda/environment.yml .
+ RUN conda env create -f environment.yml
+ 
+ SHELL ["conda", "run", "-n", "air-quality-backend", "/bin/bash", "-c"]
+ 
+ COPY pyproject.toml .
+ RUN poetry install
+ 
+ COPY src/ ./src
+ COPY scripts/run_forecast_etl.py ./scripts/run_forecast_etl.py
+ COPY README.md logging.ini ./
 
-SHELL ["conda", "run", "-n", "air-quality-backend", "/bin/bash", "-c"]
+ COPY cron/crontab.forecast crontab
+ 
+ RUN poetry install
 
-RUN poetry install
-
-CMD [ "/usr/local/bin/supercronic", "./crontest/crontab" ]
+CMD [ "/usr/local/bin/supercronic", "./crontab" ]

--- a/air-quality-backend/cron/crontab.forecast
+++ b/air-quality-backend/cron/crontab.forecast
@@ -1,2 +1,1 @@
 30 0,12 * * * conda run --no-capture-output -n air-quality-backend python "/usr/src/app/scripts/run_forecast_etl.py"
-* /2 * * * conda run --no-capture-output -n air-quality-backend python "/usr/src/app/scripts/run_in_situ_etl.py"


### PR DESCRIPTION
Adding the initial deployment github workflows

1. etl-dock-build - this builds the docker image for the ETL cron dockerfile and publishes it to the github container repository
2. docker-deploy - this sshs into the linux environment and then pulls and runs the latest docker image for ETL