### PR TITLE
Add schema validation for locations collection

### DIFF
--- a/air-quality-backend/liquibase/12_locations_schema_validation.xml
+++ b/air-quality-backend/liquibase/12_locations_schema_validation.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:mongodb="http://www.liquibase.org/xml/ns/mongodb"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+         http://www.liquibase.org/xml/ns/mongodb
+         http://www.liquibase.org/xml/ns/mongodb/liquibase-mongodb-latest.xsd">
+
+  <changeSet id="locations_schema_validation" author="amehta">
+    <mongodb:runCommand>
+        <mongodb:command>
+          {
+            collMod: "locations",
+            validator: {
+              $jsonSchema: {
+                 bsonType: "object",
+                 title: "Location Object Validation",
+                 required: [ "name", "latitude", "longitude", "type" ],
+                 properties: {
+                    name: {
+                       bsonType: "string",
+                       description: "'name' must be a string and is required"
+                    },
+                    latitude: {
+                       bsonType: "double",
+                       minimum: -90,
+                       maximum: 90,
+                       description: "'latitude' must be a double between -90 and 90 and is required"
+                    },
+                    longitude: {
+                       bsonType: "double",
+                       minimum: -180,
+                       maximum: 180,
+                       description: "'longitude' must be a double between -180 and 180 and is required"
+                    },
+                    type: {
+                       bsonType: "string",
+                       description: "'type' must be a string and is required"
+                    },
+                    country: {
+                       bsonType: "string",
+                       description: "'country' must be a string if it is there"
+                    }
+                 }
+              }
+            },
+          }
+        </mongodb:command>
+    </mongodb:runCommand>
+  </changeSet>
+</databaseChangeLog>

--- a/air-quality-backend/liquibase/master_changelog.xml
+++ b/air-quality-backend/liquibase/master_changelog.xml
@@ -8,4 +8,5 @@
   <include file="in_situ_data.xml"/>
   <include file="locations.xml"/>
   <include file="47_update_in_situ_index.xml"/>
+  <include file="12_locations_schema_validation.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Changes

Add schema validation for documents inserted/modified for locations collection

## Screenshots

Validation applied:
![image](https://github.com/ECMWFCode4Earth/vAirify/assets/110030119/f26ee92b-5121-4bf4-9e04-84932b1c3704)


Attempt to delete:
![image](https://github.com/ECMWFCode4Earth/vAirify/assets/110030119/8f044e53-67f8-4fa0-b5eb-1255cd652588)

