### PR TITLE
Make the Repository Lowercase in workflows

### DIFF
--- a/.github/workflows/forecast-etl-docker-build.yml
+++ b/.github/workflows/forecast-etl-docker-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: build
         run: |
           cd air-quality-backend
-          docker build . -t ghcr.io/${{ github.repository }}/vairify-etl-forecast:latest -f Dockerfile.forecast.cron
+          docker build . -t ghcr.io/${github.repository@L}/vairify-etl-forecast:latest -f Dockerfile.forecast.cron
       - name: publish
         run: |
-          docker push ghcr.io/${{ github.repository }}/vairify-etl-forecast:latest
+          docker push ghcr.io/${github.repository@L}/vairify-etl-forecast:latest

--- a/.github/workflows/forecast-etl-docker-build.yml
+++ b/.github/workflows/forecast-etl-docker-build.yml
@@ -12,13 +12,16 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - name: lowercase the repository name
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
       - name: login
         run: |
-          docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN}} ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN}} | docker login --username ${{ github.actor }} --password-stdin  ghcr.io
       - name: build
         run: |
           cd air-quality-backend
-          docker build . -t ghcr.io/${github.repository@L}/vairify-etl-forecast:latest -f Dockerfile.forecast.cron
+          docker build . -t ghcr.io/${REPO}/vairify-etl-forecast:latest -f Dockerfile.forecast.cron
       - name: publish
         run: |
-          docker push ghcr.io/${github.repository@L}/vairify-etl-forecast:latest
+          docker push ghcr.io/${REPO}/vairify-etl-forecast:latest

--- a/.github/workflows/insitu-etl-docker-build.yml
+++ b/.github/workflows/insitu-etl-docker-build.yml
@@ -12,13 +12,16 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - name: lowercase the repository name
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
       - name: login
         run: |
-          docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN}} ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN}} | docker login --username ${{ github.actor }} --password-stdin  ghcr.io
       - name: build
         run: |
           cd air-quality-backend
-          docker build . -t ghcr.io/${{ github.repository }}/vairify-etl-insitu:latest -f Dockerfile.insitu.cron
+          docker build . -t ghcr.io/${REPO}/vairify-etl-insitu:latest -f Dockerfile.insitu.cron
       - name: publish
         run: |
-          docker push ghcr.io/${{ github.repository }}/vairify-etl-insitu:latest
+          docker push ghcr.io/${REPO}/vairify-etl-insitu:latest


### PR DESCRIPTION
The docker commands require the image names to be lowercase.

When using the github.repository variable, as the org/repo string (ECMWFCode4Earth/vAirify) contains upper case characters this needs lowercasing.

Added a step to make the variable lowercase

Also removed warnings around the log in, this update pipes in the password rather needing to be explicitly provided... ish