### PR TITLE
55 parameterise base forecast time

### DIFF
--- a/air-quality-backend/scripts/run_forecast_etl.py
+++ b/air-quality-backend/scripts/run_forecast_etl.py
@@ -3,7 +3,7 @@ import os
 from logging import config
 
 from dotenv import load_dotenv
-from datetime import datetime, timezone
+from datetime import datetime
 from air_quality.database.forecasts import insert_data
 from air_quality.database.locations import get_locations_by_type, AirQualityLocationType
 from air_quality.etl.forecast.forecast_adapter import transform
@@ -18,7 +18,7 @@ def main():
     cities = get_locations_by_type(AirQualityLocationType.CITY)
     logging.info(f"Finding data for {cities.__len__()} cities")
 
-    base_date = datetime.now(tz=timezone.utc)
+    base_date = datetime.utcnow()
     base_date_env = os.environ.get("FORECAST_INITIAL_DATE_TIME")
     if base_date_env is not None:
         date_format = "%Y-%m-%d %H"

--- a/air-quality-backend/scripts/run_forecast_etl.py
+++ b/air-quality-backend/scripts/run_forecast_etl.py
@@ -1,8 +1,9 @@
 import logging
+import os
 from logging import config
 
 from dotenv import load_dotenv
-
+from datetime import datetime, timezone
 from air_quality.database.forecasts import insert_data
 from air_quality.database.locations import get_locations_by_type, AirQualityLocationType
 from air_quality.etl.forecast.forecast_adapter import transform
@@ -17,8 +18,14 @@ def main():
     cities = get_locations_by_type(AirQualityLocationType.CITY)
     logging.info(f"Finding data for {cities.__len__()} cities")
 
+    base_date = datetime.now(tz=timezone.utc)
+    base_date_env = os.environ.get("FORECAST_INITIAL_DATE_TIME")
+    if base_date_env is not None:
+        date_format = "%Y-%m-%d %H"
+        base_date = datetime.strptime(base_date_env, date_format)
+
     logging.info("Extracting pollutant forecast data")
-    extracted_forecast_data = fetch_forecast_data()
+    extracted_forecast_data = fetch_forecast_data(base_date)
 
     logging.info("Transforming forecast data")
     transformed_forecast_data = transform(extracted_forecast_data, cities)

--- a/air-quality-backend/scripts/run_forecast_etl.py
+++ b/air-quality-backend/scripts/run_forecast_etl.py
@@ -19,7 +19,7 @@ def main():
     logging.info(f"Finding data for {cities.__len__()} cities")
 
     base_date = datetime.utcnow()
-    base_date_env = os.environ.get("FORECAST_INITIAL_DATE_TIME")
+    base_date_env = os.environ.get("FORECAST_BASE_TIME")
     if base_date_env is not None:
         date_format = "%Y-%m-%d %H"
         base_date = datetime.strptime(base_date_env, date_format)

--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_dao.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_dao.py
@@ -71,19 +71,35 @@ def fetch_cams_data(request_body, file_name) -> xr.Dataset:
     )
 
 
-def align_to_cams_publish_time(model_date_time: datetime) -> datetime:
-    current_hour = int(model_date_time.strftime("%H"))
-    # CAMS data becomes available for current day, midnight at 10AM UTC
-    if 10 <= current_hour < 22:
-        hour = 0
-    # CAMS data becomes available for current day, midday at 10PM UTC
-    elif 22 <= current_hour < 24:
-        hour = 12
+def align_to_cams_publish_time(forecast_base_time: datetime) -> datetime:
+    now = datetime.utcnow()
+    if forecast_base_time > now:
+        raise ValueError("forecast base data cannot be in the future")
+
+    request_for_today = forecast_base_time.date() == now.date()
+
+    current_hour = int(now.strftime("%H"))
+    requested_hour = int(forecast_base_time.strftime("%H"))
+
+    if request_for_today:
+        if 0 <= current_hour < 10:
+            # If asking before 10am, only yesterdays is available
+            forecast_base_time -= timedelta(days=1)
+            hour = 12
+        elif requested_hour >= 12 and current_hour >= 22:
+            # If requesting post midday data, it must be past 10pm
+            hour = 12
+        else:
+            # Either the request was for morning data, or that's all that is available
+            hour = 0
     else:
-        model_date_time -= timedelta(days=1)
-        hour = 12
+        if requested_hour < 12:
+            hour = 0
+        else:
+            hour = 12
+
     return datetime(
-        model_date_time.year, model_date_time.month, model_date_time.day, hour
+        forecast_base_time.year, forecast_base_time.month, forecast_base_time.day, hour
     )
 
 

--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_dao.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_dao.py
@@ -1,5 +1,5 @@
 import cdsapi
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import logging
 import os
 import xarray as xr
@@ -104,7 +104,7 @@ def align_to_cams_publish_time(forecast_base_time: datetime) -> datetime:
 
 
 def fetch_forecast_data(
-    base_datetime: datetime = datetime.now(tz=timezone.utc),
+    base_datetime: datetime = datetime.utcnow(),
     no_of_forecast_times: int = 41,
 ) -> ForecastData:
 

--- a/air-quality-backend/tests/etl/forecast/forecast_dao_test.py
+++ b/air-quality-backend/tests/etl/forecast/forecast_dao_test.py
@@ -2,6 +2,9 @@ import pytest
 
 from datetime import datetime
 from unittest.mock import call, patch
+
+from freezegun import freeze_time
+
 from air_quality.etl.forecast.forecast_dao import (
     CamsRequestDetails,
     fetch_forecast_data,
@@ -136,20 +139,61 @@ def test__get_multi_level_request_body():
 @pytest.mark.parametrize(
     "str_to_align, expected_str",
     [
-        ("2024-05-22 00:00:00", "2024-05-21 12:00:00"),
-        ("2024-05-22 09:59:59", "2024-05-21 12:00:00"),
+        ("2024-05-22 00:00:00", "2024-05-22 00:00:00"),
+        ("2024-05-22 09:59:59", "2024-05-22 00:00:00"),
         ("2024-05-22 10:00:00", "2024-05-22 00:00:00"),
-        ("2024-05-22 21:59:59", "2024-05-22 00:00:00"),
+        ("2024-05-22 12:00:00", "2024-05-22 12:00:00"),
+        ("2024-05-22 21:59:59", "2024-05-22 12:00:00"),
         ("2024-05-22 22:00:00", "2024-05-22 12:00:00"),
         ("2024-05-22 23:59:59", "2024-05-22 12:00:00"),
     ],
 )
-def test__align_to_cams_publish_time(str_to_align: str, expected_str: str):
+@freeze_time("2024-05-28 00:00:00")
+def test__align_to_cams_publish_time__older_dates_retrieve_relevant_cams_time(
+    str_to_align: str, expected_str: str
+):
     date_to_align = datetime.strptime(str_to_align, "%Y-%m-%d %H:%M:%S")
     expected = datetime.strptime(expected_str, "%Y-%m-%d %H:%M:%S")
 
     result = align_to_cams_publish_time(date_to_align)
+
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "current_time, str_to_align, expected_str",
+    [
+        ("2024-05-22 00:00:00", "2024-05-22 00:00:00", "2024-05-21 12:00:00"),
+        ("2024-05-22 09:59:59", "2024-05-22 00:00:00", "2024-05-21 12:00:00"),
+        ("2024-05-22 10:00:00", "2024-05-22 00:00:00", "2024-05-22 00:00:00"),
+        ("2024-05-22 12:00:00", "2024-05-22 12:00:00", "2024-05-22 00:00:00"),
+        ("2024-05-22 21:59:59", "2024-05-22 12:00:00", "2024-05-22 00:00:00"),
+        ("2024-05-22 22:00:00", "2024-05-22 12:00:00", "2024-05-22 12:00:00"),
+        ("2024-05-22 23:59:59", "2024-05-22 12:00:00", "2024-05-22 12:00:00"),
+        ("2024-05-23 00:00:00", "2024-05-22 23:59:59", "2024-05-22 12:00:00"),
+    ],
+)
+def test__align_to_cams_publish_time__same_day_dates_retrieve_relevant_cams_time(
+    current_time: str, str_to_align: str, expected_str: str
+):
+    freezer = freeze_time(current_time)
+    try:
+        freezer.start()
+        date_to_align = datetime.strptime(str_to_align, "%Y-%m-%d %H:%M:%S")
+        expected = datetime.strptime(expected_str, "%Y-%m-%d %H:%M:%S")
+
+        result = align_to_cams_publish_time(date_to_align)
+
+        assert result == expected
+    finally:
+        freezer.stop()
+
+
+@freeze_time("2024-05-28 11:00:00")
+def test__align_to_cams_publish_time__requested_future_base_time_raises_error():
+    requested_time = datetime(2024, 5, 28, 11, 00, 1)  # 1 min in the future
+    with pytest.raises(ValueError):
+        align_to_cams_publish_time(requested_time)
 
 
 def test_fetch_forecast_data_returns_forecast_data(mocker, mock_open_dataset):
@@ -162,13 +206,13 @@ def test_fetch_forecast_data_returns_forecast_data(mocker, mock_open_dataset):
     mock_open_dataset.assert_has_calls(
         [
             call(
-                "single_level_41_from_2024-05-19_12.grib",
+                "single_level_41_from_2024-05-20_00.grib",
                 decode_times=False,
                 engine="cfgrib",
                 backend_kwargs={"indexpath": ""},
             ),
             call(
-                "multi_level_41_from_2024-05-19_12.grib",
+                "multi_level_41_from_2024-05-20_00.grib",
                 decode_times=False,
                 engine="cfgrib",
                 backend_kwargs={"indexpath": ""},

--- a/air-quality-backend/tests/scripts/run_forecast_etl_test.py
+++ b/air-quality-backend/tests/scripts/run_forecast_etl_test.py
@@ -33,7 +33,7 @@ def test__run_forecast_etl__no_forecast_time_in_environment_uses_now(
         main()
 
         expected_datetime = datetime(2024, 5, 24, 11, 12, 13, 0)
-        mock_os.assert_called_with("FORECAST_INITIAL_DATE_TIME")
+        mock_os.assert_called_with("FORECAST_BASE_TIME")
         mock_locations.assert_called_with(AirQualityLocationType.CITY)
         mock_fetch.assert_called_with(expected_datetime)
         mock_transform.assert_called_with(forecast_data, cities)
@@ -58,7 +58,7 @@ def test__run_forecast_etl__forecast_time_in_environment_uses(
         main()
 
         expected_datetime = datetime(2024, 6, 1, 17, 0, 0, 0)
-        mock_os.assert_called_with("FORECAST_INITIAL_DATE_TIME")
+        mock_os.assert_called_with("FORECAST_BASE_TIME")
         mock_locations.assert_called_with(AirQualityLocationType.CITY)
         mock_fetch.assert_called_with(expected_datetime)
         mock_transform.assert_called_with(forecast_data, cities)

--- a/air-quality-backend/tests/scripts/run_forecast_etl_test.py
+++ b/air-quality-backend/tests/scripts/run_forecast_etl_test.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timezone
 from unittest.mock import patch
+
+from freezegun import freeze_time
 
 from air_quality.database.locations import AirQualityLocationType
 from air_quality.etl.forecast.forecast_data import ForecastData
@@ -16,15 +19,47 @@ transformed_forecast_data = []
 @patch("scripts.run_forecast_etl.transform")
 @patch("scripts.run_forecast_etl.fetch_forecast_data")
 @patch("scripts.run_forecast_etl.get_locations_by_type")
-def test__run_forecast_etl(mock_locations, mock_fetch, mock_transform, mock_insert):
+@patch("os.environ.get")
+@freeze_time("2024-05-24T11:12:13")
+def test__run_forecast_etl__no_forecast_time_in_environment_uses_now(
+    mock_os, mock_locations, mock_fetch, mock_transform, mock_insert
+):
     with patch("scripts.run_forecast_etl.config.fileConfig"):
+        mock_os.return_value = None
         mock_locations.return_value = cities
         mock_fetch.return_value = forecast_data
         mock_transform.return_value = transformed_forecast_data
 
         main()
 
+        expected_datetime = datetime(2024, 5, 24, 11, 12, 13, 0, timezone.utc)
+        mock_os.assert_called_with("FORECAST_INITIAL_DATE_TIME")
         mock_locations.assert_called_with(AirQualityLocationType.CITY)
-        mock_fetch.assert_called()
+        mock_fetch.assert_called_with(expected_datetime)
+        mock_transform.assert_called_with(forecast_data, cities)
+        mock_insert.assert_called_with(transformed_forecast_data)
+
+
+@patch("scripts.run_forecast_etl.insert_data")
+@patch("scripts.run_forecast_etl.transform")
+@patch("scripts.run_forecast_etl.fetch_forecast_data")
+@patch("scripts.run_forecast_etl.get_locations_by_type")
+@patch("os.environ.get")
+@freeze_time("2024-05-24T11:12:13")
+def test__run_forecast_etl__forecast_time_in_environment_uses(
+    mock_os, mock_locations, mock_fetch, mock_transform, mock_insert
+):
+    with patch("scripts.run_forecast_etl.config.fileConfig"):
+        mock_os.return_value = "2024-06-01 17"
+        mock_locations.return_value = cities
+        mock_fetch.return_value = forecast_data
+        mock_transform.return_value = transformed_forecast_data
+
+        main()
+
+        expected_datetime = datetime(2024, 6, 1, 17, 0, 0, 0)
+        mock_os.assert_called_with("FORECAST_INITIAL_DATE_TIME")
+        mock_locations.assert_called_with(AirQualityLocationType.CITY)
+        mock_fetch.assert_called_with(expected_datetime)
         mock_transform.assert_called_with(forecast_data, cities)
         mock_insert.assert_called_with(transformed_forecast_data)

--- a/air-quality-backend/tests/scripts/run_forecast_etl_test.py
+++ b/air-quality-backend/tests/scripts/run_forecast_etl_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -32,7 +32,7 @@ def test__run_forecast_etl__no_forecast_time_in_environment_uses_now(
 
         main()
 
-        expected_datetime = datetime(2024, 5, 24, 11, 12, 13, 0, timezone.utc)
+        expected_datetime = datetime(2024, 5, 24, 11, 12, 13, 0)
         mock_os.assert_called_with("FORECAST_INITIAL_DATE_TIME")
         mock_locations.assert_called_with(AirQualityLocationType.CITY)
         mock_fetch.assert_called_with(expected_datetime)


### PR DESCRIPTION
Allows you to override the forecast base time by adding it to the .env file, i.e. FORECAST_BASE_TIME=2024-5-25 12

Also sorts out an issue calculating the valid forecast base date didn't account for dates that weren't the current day.

