### PR TITLE
Retry on 408 failures to OpenAQ

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -22,6 +22,7 @@ jobs:
           ssh ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd /usr/config && \\
             echo MONGO_DB_URI=${{ secrets.MONGO_URI }} | sudo tee .env && \\
             echo MONGO_DB_NAME=${{ secrets.MONGO_DB_NAME }} | sudo tee -a .env && \\
+            echo OPEN_AQ_API_URL=${{ secrets.OPEN_AQ_API_URL }} | sudo tee -a .env && \\
             echo OPEN_AQ_API_KEY=${{ secrets.OPEN_AQ_API_KEY }} | sudo tee -a .env && \\
             echo CDSAPI_URL=${{ secrets.CDSAPI_URL }} | sudo tee -a .env && \\
             echo CDSAPI_KEY=${{ secrets.CDSAPI_KEY }} | sudo tee -a .env && \\

--- a/air-quality-backend/README.md
+++ b/air-quality-backend/README.md
@@ -51,6 +51,7 @@ Add in the following environment variables e.g.
 ```
 MONGO_DB_URI=mongodb+srv://<username:password>@cluster0.ch5gkk4.mongodb.net/
 MONGO_DB_NAME=air_quality_dashboard_db
+OPEN_AQ_API_URL=https://api.openaq.org
 OPEN_AQ_API_KEY=<api_key>
 ```
 

--- a/air-quality-backend/poetry.lock
+++ b/air-quality-backend/poetry.lock
@@ -1338,6 +1338,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "requests-mock"
+version = "1.12.1"
+description = "Mock out responses from the requests package"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401"},
+    {file = "requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563"},
+]
+
+[package.dependencies]
+requests = ">=2.22,<3"
+
+[package.extras]
+fixture = ["fixtures"]
+
+[[package]]
 name = "rich"
 version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -1864,4 +1881,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.9"
-content-hash = "357211d64cad8e7f39be53f3f5a17f728301df12a73450c8d7d2491eca9482c0"
+content-hash = "e90613349cc220f798ba5a6b9eedafd77440387b45db565461aba5ee08f8a766"

--- a/air-quality-backend/poetry.lock
+++ b/air-quality-backend/poetry.lock
@@ -1187,6 +1187,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-httpserver"
+version = "1.0.10"
+description = "pytest-httpserver is a httpserver for pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_httpserver-1.0.10-py3-none-any.whl", hash = "sha256:d40e0cc3d61ed6e4d80f52a796926d557a7db62b17e43b3e258a78a3c34becb9"},
+    {file = "pytest_httpserver-1.0.10.tar.gz", hash = "sha256:77b9fbc2eb0a129cfbbacc8fe57e8cafe071d506489f31fe31e62f1b332d9905"},
+]
+
+[package.dependencies]
+Werkzeug = ">=2.0.0"
+
+[[package]]
 name = "pytest-mock"
 version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -1336,23 +1350,6 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "requests-mock"
-version = "1.12.1"
-description = "Mock out responses from the requests package"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401"},
-    {file = "requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563"},
-]
-
-[package.dependencies]
-requests = ">=2.22,<3"
-
-[package.extras]
-fixture = ["fixtures"]
 
 [[package]]
 name = "rich"
@@ -1878,7 +1875,24 @@ files = [
     {file = "websockets-12.0.tar.gz", hash = "sha256:81df9cbcbb6c260de1e007e58c011bfebe2dafc8435107b0537f393dd38c8b1b"},
 ]
 
+[[package]]
+name = "werkzeug"
+version = "3.0.3"
+description = "The comprehensive WSGI web application library."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "werkzeug-3.0.3-py3-none-any.whl", hash = "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8"},
+    {file = "werkzeug-3.0.3.tar.gz", hash = "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog (>=2.3)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.9"
-content-hash = "e90613349cc220f798ba5a6b9eedafd77440387b45db565461aba5ee08f8a766"
+content-hash = "f4b6464da2b73b7b4aa8d02cba72dbb98393ac13dbc6c0ecbb96c943043e98a4"

--- a/air-quality-backend/pyproject.toml
+++ b/air-quality-backend/pyproject.toml
@@ -30,6 +30,7 @@ mongomock = "^4.1.2"
 pytest = "8.1.1"
 pytest-cov = "5.0.0"
 pytest-mock = "3.14.0"
+requests-mock = "^1.12.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/air-quality-backend/pyproject.toml
+++ b/air-quality-backend/pyproject.toml
@@ -30,7 +30,7 @@ mongomock = "^4.1.2"
 pytest = "8.1.1"
 pytest-cov = "5.0.0"
 pytest-mock = "3.14.0"
-requests-mock = "^1.12.1"
+pytest-httpserver = "^1.0.10"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
+++ b/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
@@ -7,7 +7,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-base_url = "https://api.openaq.org/v2/measurements"
+measurements_path = "/v2/measurements"
 
 
 def _create_session() -> requests.Session:
@@ -35,7 +35,7 @@ def _call_openaq_api(
         "coordinates": str(city["latitude"]) + "," + str(city["longitude"]),
         "parameter": ["o3", "no2", "pm10", "so2", "pm25"],
     }
-    url = base_url + "?" + urlencode(query_params, doseq=True)
+    url = f"{os.environ.get('OPEN_AQ_API_URL')}/{measurements_path}?{urlencode(query_params, doseq=True)}"
     headers = {"X-API-Key": os.environ.get("OPEN_AQ_API_KEY")}
     logging.debug(f"Calling OpenAQ: {url}")
     try:

--- a/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
+++ b/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
@@ -35,7 +35,11 @@ def _call_openaq_api(
         "coordinates": str(city["latitude"]) + "," + str(city["longitude"]),
         "parameter": ["o3", "no2", "pm10", "so2", "pm25"],
     }
-    url = f"{os.environ.get('OPEN_AQ_API_URL')}/{measurements_path}?{urlencode(query_params, doseq=True)}"
+    url = "{}/{}?{}".format(
+        os.environ.get("OPEN_AQ_API_URL"),
+        measurements_path,
+        urlencode(query_params, doseq=True),
+    )
     headers = {"X-API-Key": os.environ.get("OPEN_AQ_API_KEY")}
     logging.debug(f"Calling OpenAQ: {url}")
     try:

--- a/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
+++ b/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
@@ -1,22 +1,27 @@
-from datetime import datetime
 import logging
 import os
-import requests
+from datetime import datetime
 from urllib.parse import urlencode
 
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 base_url = "https://api.openaq.org/v2/measurements"
 
 
-def fetch_in_situ_measurements(cities, date_from: datetime, date_to: datetime):
-    in_situ_data_by_city = {}
-    for city in cities:
-        results = call_openaq_api(city, date_from, date_to)
-        in_situ_data_by_city[city["name"]] = {"measurements": results, "city": city}
-    return in_situ_data_by_city
+def _create_session() -> requests.Session:
+    retry_strategy = Retry(total=3, status_forcelist=[408], raise_on_status=False)
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
 
 
-def call_openaq_api(city, date_from: datetime, date_to: datetime) -> list:
+def _call_openaq_api(
+    city, date_from: datetime, date_to: datetime, session: requests.Session
+) -> list:
     limit = 3000
     query_params = {
         "limit": limit,
@@ -27,24 +32,30 @@ def call_openaq_api(city, date_from: datetime, date_to: datetime) -> list:
         "radius": "25000",
         "date_to": date_to.strftime("%Y-%m-%dT%H:%M:%S%z"),
         "date_from": date_from.strftime("%Y-%m-%dT%H:%M:%S%z"),
-        "coordinates": format_coordinates(city),
+        "coordinates": str(city["latitude"]) + "," + str(city["longitude"]),
         "parameter": ["o3", "no2", "pm10", "so2", "pm25"],
     }
     url = base_url + "?" + urlencode(query_params, doseq=True)
     headers = {"X-API-Key": os.environ.get("OPEN_AQ_API_KEY")}
     logging.debug(f"Calling OpenAQ: {url}")
-    response_json = requests.get(url, headers=headers).json()
-    results = response_json.get("results")
-    if results is not None:
+    try:
+        response = session.get(url, headers=headers)
+        response.raise_for_status()
+        response_json = response.json()
+        results = response_json.get("results")
         if len(results) > limit:
             logging.warning(f"More results were present for: {city['name']}")
         return results
-    else:
-        logging.warning(
-            f"Response for {city['name']} contained no results: {response_json}"
-        )
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Response for {city['name']} contained no results: {e.response}")
+        logging.error(f"URL was: {url}")
         return []
 
 
-def format_coordinates(city):
-    return str(city["latitude"]) + "," + str(city["longitude"])
+def fetch_in_situ_measurements(cities, date_from: datetime, date_to: datetime):
+    in_situ_data_by_city = {}
+    session = _create_session()
+    for city in cities:
+        results = _call_openaq_api(city, date_from, date_to, session)
+        in_situ_data_by_city[city["name"]] = {"measurements": results, "city": city}
+    return in_situ_data_by_city

--- a/air-quality-backend/tests/etl/in_situ/openaq_dao_test.py
+++ b/air-quality-backend/tests/etl/in_situ/openaq_dao_test.py
@@ -1,5 +1,8 @@
+import re
 from datetime import datetime
 from unittest.mock import patch, Mock
+
+import requests_mock
 
 from air_quality.etl.in_situ.openaq_dao import fetch_in_situ_measurements, base_url
 
@@ -15,13 +18,13 @@ def test__fetch_in_situ_measurements__no_cities_returns_empty():
 
 
 @patch("air_quality.etl.in_situ.openaq_dao.urlencode")
-@patch("air_quality.etl.in_situ.openaq_dao.requests")
+@patch("air_quality.etl.in_situ.openaq_dao.requests.Session.get")
 def test__fetch_in_situ_measurements__correct_url_params_encoded(
     requests_patch, urlencode_patch
 ):
     response_mock = Mock()
     response_mock.json.return_value = {"results": []}
-    requests_patch.get.return_value = response_mock
+    requests_patch.return_value = response_mock
 
     cities = [{"name": "London", "latitude": 11, "longitude": 22}]
     fetch_in_situ_measurements(cities, date_from, date_to)
@@ -44,7 +47,7 @@ def test__fetch_in_situ_measurements__correct_url_params_encoded(
 
 
 @patch("air_quality.etl.in_situ.openaq_dao.urlencode")
-@patch("air_quality.etl.in_situ.openaq_dao.requests")
+@patch("air_quality.etl.in_situ.openaq_dao.requests.Session.get")
 @patch("air_quality.etl.in_situ.openaq_dao.os")
 def test__fetch_in_situ_measurements__correct_url_called(
     os_patch, requests_patch, urlencode_patch
@@ -53,21 +56,21 @@ def test__fetch_in_situ_measurements__correct_url_called(
     os_patch.environ.get.return_value = "test_api_key"
     response_mock = Mock()
     response_mock.json.return_value = {"results": []}
-    requests_patch.get.return_value = response_mock
+    requests_patch.return_value = response_mock
 
     cities = [{"name": "London", "latitude": 11, "longitude": 22}]
     fetch_in_situ_measurements(cities, date_from, date_to)
 
-    requests_patch.get.assert_called_with(
+    requests_patch.assert_called_with(
         f"{base_url}?test_url_params", headers={"X-API-Key": "test_api_key"}
     )
 
 
-@patch("air_quality.etl.in_situ.openaq_dao.requests")
+@patch("air_quality.etl.in_situ.openaq_dao.requests.Session.get")
 def test__fetch_in_situ_measurements__single_city_without_measurements(requests_patch):
     response_mock = Mock()
     response_mock.json.return_value = {"results": []}
-    requests_patch.get.return_value = response_mock
+    requests_patch.return_value = response_mock
 
     cities = [{"name": "London", "latitude": 11, "longitude": 22}]
     result = fetch_in_situ_measurements(cities, date_from, date_to)
@@ -76,11 +79,11 @@ def test__fetch_in_situ_measurements__single_city_without_measurements(requests_
     assert result["London"]["measurements"] == []
 
 
-@patch("air_quality.etl.in_situ.openaq_dao.requests")
+@patch("air_quality.etl.in_situ.openaq_dao.requests.Session.get")
 def test__fetch_in_situ_measurements__single_city_multiple_measurements(requests_patch):
     response_mock = Mock()
     response_mock.json.return_value = {"results": [100, 200]}
-    requests_patch.get.return_value = response_mock
+    requests_patch.return_value = response_mock
 
     cities = [{"name": "London", "latitude": 11, "longitude": 22}]
     result = fetch_in_situ_measurements(cities, date_from, date_to)
@@ -89,13 +92,13 @@ def test__fetch_in_situ_measurements__single_city_multiple_measurements(requests
     assert result["London"]["measurements"] == [100, 200]
 
 
-@patch("air_quality.etl.in_situ.openaq_dao.requests")
+@patch("air_quality.etl.in_situ.openaq_dao.requests.Session.get")
 def test__fetch_in_situ_measurements__single_city_too_many_measurements(requests_patch):
     response_mock = Mock()
 
     results = range(0, 3001)
     response_mock.json.return_value = {"results": results}
-    requests_patch.get.return_value = response_mock
+    requests_patch.return_value = response_mock
 
     cities = [{"name": "London", "latitude": 11, "longitude": 22}]
     result = fetch_in_situ_measurements(cities, date_from, date_to)
@@ -104,11 +107,11 @@ def test__fetch_in_situ_measurements__single_city_too_many_measurements(requests
     assert result["London"]["measurements"] == results
 
 
-@patch("air_quality.etl.in_situ.openaq_dao.requests")
+@patch("air_quality.etl.in_situ.openaq_dao.requests.Session.get")
 def test__fetch_in_situ_measurements__multiple_cities(requests_patch):
     response_mock = Mock()
-    response_mock.json.return_value = {}
-    requests_patch.get.return_value = response_mock
+    response_mock.json.return_value = {"results": []}
+    requests_patch.return_value = response_mock
 
     cities = [
         {"name": "London", "latitude": 11, "longitude": 22},
@@ -118,3 +121,16 @@ def test__fetch_in_situ_measurements__multiple_cities(requests_patch):
 
     assert result["London"]["city"] == cities[0]
     assert result["Dublin"]["city"] == cities[1]
+
+
+def test__fetch_in_situ_measurements__handles_error():
+    with requests_mock.Mocker() as m:
+        m.get(
+            re.compile(f"^{base_url}.*"),
+            base_url[{"status_code": 408},],
+        )
+        cities = [{"name": "London", "latitude": 11, "longitude": 22}]
+        result = fetch_in_situ_measurements(cities, date_from, date_to)
+
+        assert result["London"]["city"] == cities[0]
+        assert result["London"]["measurements"] == []

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,7 @@ services:
     environment:
       - MONGO_DB_URI=${MONGO_DB_URI}
       - MONGO_DB_NAME=${MONGO_DB_NAME}
+      - OPEN_AQ_API_URL=${OPEN_AQ_API_URL}
       - OPEN_AQ_API_KEY=${OPEN_AQ_API_KEY}
       - CDSAPI_URL=${CDSAPI_URL}
       - CDSAPI_KEY=${CDSAPI_KEY}

--- a/deployment/compose.yaml
+++ b/deployment/compose.yaml
@@ -5,6 +5,7 @@ services:
     environment:
       - MONGO_DB_URI=${MONGO_DB_URI}
       - MONGO_DB_NAME=${MONGO_DB_NAME}
+      - OPEN_AQ_API_URL=${OPEN_AQ_API_URL}
       - OPEN_AQ_API_KEY=${OPEN_AQ_API_KEY}
       - CDSAPI_URL=${CDSAPI_URL}
       - CDSAPI_KEY=${CDSAPI_KEY}


### PR DESCRIPTION
## Changes

Requests to open AQ will be retried up to 3 times in the response has status code 408 (connection timeout)

Required making open AQ URL an environment variable for testability

Also updated secret in github:

![image](https://github.com/ECMWFCode4Earth/vAirify/assets/110030119/7759ecf0-a48d-42a7-9d5b-3a23ac62955a)
