### PR TITLE
Add root path

### DIFF
--- a/air-quality-backend/Dockerfile.api
+++ b/air-quality-backend/Dockerfile.api
@@ -14,4 +14,4 @@ COPY README.md logging.ini ./
 
 RUN poetry install 
 
-ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "air-quality-backend", "fastapi", "run", "./src/air_quality/api/main.py"]
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "air-quality-backend", "fastapi", "run", "./src/air_quality/api/main.py", "--root-path", "/api"]


### PR DESCRIPTION
Had an issue on the server where the relative paths were not matching the reverse proxy server forwarding.

Adding the CLI option --root-path ensures that /api will be added appropriately where required