### PR TITLE
Test for open aq retries

### DIFF
--- a/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
+++ b/air-quality-backend/src/air_quality/etl/in_situ/openaq_dao.py
@@ -12,7 +12,7 @@ measurements_path = "/v2/measurements"
 
 
 def _create_session() -> requests.Session:
-    retry_strategy = Retry(total=3, status_forcelist=[408], raise_on_status=False)
+    retry_strategy = Retry(total=2, status_forcelist=[408], raise_on_status=False)
     adapter = HTTPAdapter(max_retries=retry_strategy)
     session = requests.Session()
     session.mount("http://", adapter)

--- a/air-quality-backend/system_tests/in_situ_etl_suite/open_aq_etl_tests.py
+++ b/air-quality-backend/system_tests/in_situ_etl_suite/open_aq_etl_tests.py
@@ -250,7 +250,7 @@ def ensure_forecast_cache():
 
 @mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
 @mock.patch.dict(os.environ, {"OPEN_AQ_CITIES": "London"})
-def test__in_situ_etl__timeouts_retry_3_times_then_stop(
+def test__in_situ_etl__timeouts_retry_twice_then_stop(
         mock_get_conn,
         caplog,
         ensure_forecast_cache):
@@ -264,7 +264,7 @@ def test__in_situ_etl__timeouts_retry_3_times_then_stop(
     assert "Response for London contained no results" in caplog.text
     results = get_database_data(collection_name, query)
     assert len(results) == 0
-    assert len(mock_get_conn.return_value.request.mock_calls) == 4
+    assert len(mock_get_conn.return_value.request.mock_calls) == 3
 
 
 @mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")

--- a/air-quality-backend/system_tests/in_situ_etl_suite/open_aq_etl_tests.py
+++ b/air-quality-backend/system_tests/in_situ_etl_suite/open_aq_etl_tests.py
@@ -24,7 +24,6 @@ from dotenv import load_dotenv
 from system_tests.utils.file_utilities import write_to_file
 
 open_aq_cache_location = "system_tests/in_situ_etl_suite"
-static_grib_file_location = "system_tests/in_situ_etl_suite/static_forecast_files"
 collection_name = "in_situ_data"
 load_dotenv()
 

--- a/air-quality-backend/tests/etl/in_situ/openaq_dao_test.py
+++ b/air-quality-backend/tests/etl/in_situ/openaq_dao_test.py
@@ -189,7 +189,7 @@ def httpserver_listen_address():
     },
 )
 def test__fetch_in_situ_measurements__retries_408_responses(httpserver: HTTPServer):
-    expected_retries = 3
+    expected_retries = 2
     for index in range(expected_retries):
         httpserver.expect_ordered_request(
             re.compile("^/v2/measurements"), method="GET"


### PR DESCRIPTION
This includes some new integration tests to check the retry functionality with open aq timeouts.
This also drops the number of timeouts from 3 to 2.