### PR TITLE
Remove copy of package-lock.json for UI dockerfile

### DIFF
--- a/air-quality-ui/Dockerfile
+++ b/air-quality-ui/Dockerfile
@@ -3,8 +3,7 @@ FROM node:22-alpine AS development
 WORKDIR /app
 
 COPY package.json package.json
-COPY package-lock.json package-lock.json
-RUN npm ci
+RUN npm i
 
 COPY . .
 


### PR DESCRIPTION
The building of the image was broken, issue is tracked to the package-lock.json which was made for windows and not linux. Removed copying so that it gets recreated for correct OS architecture