### PR TITLE
Automation Tests for: 47 create an api to query in situ data for single city page

### DIFF
--- a/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
@@ -192,12 +192,9 @@ def test__different_base_times__assert_correct_results_returned(
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
-
-    expected = expected_cities
     actual_cities = get_list_of_key_values(response.json(), "location_name")
-    for city in actual_cities:
-        index = actual_cities.index(city)
-        assert city == expected[index]
+
+    assert actual_cities == expected_cities
 
 
 @pytest.mark.parametrize(
@@ -373,11 +370,9 @@ def test__different_valid_time_from_times__assert_correct_results(
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
-    expected = expected_cities
     actual_cities = get_list_of_key_values(response.json(), "location_name")
-    for city in actual_cities:
-        index = actual_cities.index(city)
-        assert city == expected[index]
+
+    assert actual_cities == expected_cities
 
 
 @pytest.mark.parametrize(
@@ -555,11 +550,9 @@ def test__different_valid_time_to_times__assert_correct_results(
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
-    expected = expected_cities
     actual_cities = get_list_of_key_values(response.json(), "location_name")
-    for city in actual_cities:
-        index = actual_cities.index(city)
-        assert city == expected[index]
+
+    assert actual_cities == expected_cities
 
 
 @pytest.mark.parametrize(

--- a/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
@@ -111,7 +111,7 @@ test_city_2_expected_response_data: dict = {
 }
 
 # API GET request
-base_url = Routes.forecast_api_url
+base_url = Routes.forecast_api_endpoint
 headers = {"accept": "application/json"}
 location_type = "city"
 

--- a/air-quality-backend/system_tests/api_suite/forecast_api_validation_tests.py
+++ b/air-quality-backend/system_tests/api_suite/forecast_api_validation_tests.py
@@ -109,3 +109,91 @@ def test__required_and_optional_parameter_combinations_missing__verify_status_42
         "GET", base_url, headers=headers, params=payload, timeout=5.0
     )
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "payload, method",
+    [
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+                "location_name": location_name,
+            },
+            "POST",
+        ),
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+                "location_name": location_name,
+            },
+            "PUT",
+        ),
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+                "location_name": location_name,
+            },
+            "PATCH",
+        ),
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+                "location_name": location_name,
+            },
+            "DELETE",
+        ),
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+            },
+            "POST",
+        ),
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+            },
+            "PUT",
+        ),
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+            },
+            "PATCH",
+        ),
+        (
+            {
+                "base_time": base_time_string,
+                "valid_time_from": valid_time_from_string,
+                "valid_time_to": valid_time_to_string,
+                "location_type": location_type,
+            },
+            "DELETE",
+        ),
+    ],
+)
+def test__different_http_request_methods__verify_not_valid(method: str, payload: dict):
+    response = requests.request(method, base_url, params=payload, timeout=5.0)
+
+    assert response.status_code == 405
+    assert not isinstance(response.json(), list)

--- a/air-quality-backend/system_tests/api_suite/forecast_api_validation_tests.py
+++ b/air-quality-backend/system_tests/api_suite/forecast_api_validation_tests.py
@@ -8,7 +8,7 @@ from system_tests.utils.api_utilities import (
 from system_tests.data.cities_data import all_cities
 from system_tests.utils.routes import Routes
 
-base_url = Routes.forecast_api_url
+base_url = Routes.forecast_api_endpoint
 headers = {"accept": "application/json"}
 location_type = "city"
 location_name = random.choice(all_cities)

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -12,8 +12,10 @@ from system_tests.utils.api_utilities import (
     format_datetime_as_string,
     get_list_of_key_values,
 )
-from system_tests.utils.cams_utilities import delete_database_data
-from system_tests.utils.database_utilities import seed_api_test_data
+from system_tests.utils.database_utilities import (
+    seed_api_test_data,
+    delete_database_data,
+)
 from system_tests.utils.routes import Routes
 
 # Parameter Test Data

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -137,6 +137,10 @@ date_to_string_24_6_21_16_0_0 = format_datetime_as_string(
 date_to_string_24_7_29_15_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 7, 29, 15, 0, 0), "%Y-%m-%dT%H:%M:%SZ"
 )
+api_source_open_aq = "OpenAQ"
+location_names_test_city_1 = "Test City 1"
+location_names_test_city_2 = "Test City 2"
+location_names_test_city_3 = "Test City 3"
 
 # Test Setup
 load_dotenv(".env-qa")
@@ -192,7 +196,7 @@ seed_api_test_data(
         ),
     ],
 )
-def test__different_measurement_dates__assert_response_location_names_are_correct(
+def test__different_date_from_and_date_to_ranges__assert_response_location_names_are_correct(
     api_parameters: dict, expected_location_names: str
 ):
     load_dotenv(".env-qa")
@@ -238,7 +242,7 @@ def test__different_measurement_dates__assert_response_location_names_are_correc
         ),
     ],
 )
-def test__different_measurement_dates__assert_response_site_names_are_correct(
+def test__different_date_from_and_date_to_ranges__assert_response_site_names_are_correct(
     api_parameters: dict, expected_site_names: str
 ):
     load_dotenv(".env-qa")
@@ -317,7 +321,7 @@ def test__different_measurement_dates__assert_response_site_names_are_correct(
         ),
     ],
 )
-def test__different_measurement_dates__assert_response_measurement_dates_are_correct(
+def test__different_date_from_and_date_to_ranges__assert_response_measurement_dates_are_correct(
     api_parameters: dict, expected_measurement_dates: str
 ):
     load_dotenv(".env-qa")
@@ -329,3 +333,275 @@ def test__different_measurement_dates__assert_response_measurement_dates_are_cor
     actual_measurement_dates.sort()
 
     assert actual_measurement_dates == expected_measurement_dates
+
+
+@pytest.mark.parametrize(
+    "api_parameters, expected_location_names",
+    [
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_1,
+                "api_source": api_source_open_aq,
+            },
+            [test_city_1_site_1_2024_6_21_15_0_0["name"]],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_1,
+            },
+            [test_city_1_site_1_2024_6_21_15_0_0["name"]],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_3,
+                "api_source": api_source_open_aq,
+            },
+            [
+                test_city_3_site_1_2024_6_21_14_30_0["name"],
+                test_city_3_site_1_2024_6_21_14_45_0["name"],
+                test_city_3_site_2_2024_6_21_15_30_0["name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_3,
+            },
+            [
+                test_city_3_site_1_2024_6_21_14_30_0["name"],
+                test_city_3_site_1_2024_6_21_14_45_0["name"],
+                test_city_3_site_2_2024_6_21_15_30_0["name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": [
+                    location_names_test_city_1,
+                    location_names_test_city_2,
+                    location_names_test_city_3,
+                ],
+                "api_source": api_source_open_aq,
+            },
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["name"],
+                test_city_2_site_1_2024_6_21_14_0_0["name"],
+                test_city_2_site_2_2024_6_21_16_0_0["name"],
+                test_city_3_site_1_2024_6_21_14_30_0["name"],
+                test_city_3_site_1_2024_6_21_14_45_0["name"],
+                test_city_3_site_2_2024_6_21_15_30_0["name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": [
+                    location_names_test_city_1,
+                    location_names_test_city_2,
+                    location_names_test_city_3,
+                ],
+            },
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["name"],
+                test_city_2_site_1_2024_6_21_14_0_0["name"],
+                test_city_2_site_2_2024_6_21_16_0_0["name"],
+                test_city_3_site_1_2024_6_21_14_30_0["name"],
+                test_city_3_site_1_2024_6_21_14_45_0["name"],
+                test_city_3_site_2_2024_6_21_15_30_0["name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": ["Test City 5"],
+                "api_source": api_source_open_aq,
+            },
+            [],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": ["Test City 5"],
+            },
+            [],
+        ),
+    ],
+)
+def test__different_location_names__assert_response_location_names_are_correct(
+    api_parameters: dict, expected_location_names: str
+):
+    load_dotenv(".env-qa")
+    response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+
+    actual_location_names = get_list_of_key_values(response.json(), "location_name")
+    actual_location_names.sort()
+
+    assert actual_location_names == expected_location_names
+
+
+@pytest.mark.parametrize(
+    "api_parameters, expected_site_names",
+    [
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_1,
+                "api_source": api_source_open_aq,
+            },
+            [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_1,
+            },
+            [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_3,
+                "api_source": api_source_open_aq,
+            },
+            [
+                test_city_3_site_1_2024_6_21_14_30_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_45_0["location_name"],
+                test_city_3_site_2_2024_6_21_15_30_0["location_name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": location_names_test_city_3,
+            },
+            [
+                test_city_3_site_1_2024_6_21_14_30_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_45_0["location_name"],
+                test_city_3_site_2_2024_6_21_15_30_0["location_name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": [
+                    location_names_test_city_1,
+                    location_names_test_city_2,
+                    location_names_test_city_3,
+                ],
+                "api_source": api_source_open_aq,
+            },
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["location_name"],
+                test_city_2_site_1_2024_6_21_14_0_0["location_name"],
+                test_city_2_site_2_2024_6_21_16_0_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_30_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_45_0["location_name"],
+                test_city_3_site_2_2024_6_21_15_30_0["location_name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": [
+                    location_names_test_city_1,
+                    location_names_test_city_2,
+                    location_names_test_city_3,
+                ],
+            },
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["location_name"],
+                test_city_2_site_1_2024_6_21_14_0_0["location_name"],
+                test_city_2_site_2_2024_6_21_16_0_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_30_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_45_0["location_name"],
+                test_city_3_site_2_2024_6_21_15_30_0["location_name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": ["Test City 5"],
+                "api_source": api_source_open_aq,
+            },
+            [],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_name": ["Test City 5"],
+            },
+            [],
+        ),
+    ],
+)
+def test__different_location_names__assert_response_site_names_are_correct(
+    api_parameters: dict, expected_site_names: str
+):
+    load_dotenv(".env-qa")
+    response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+
+    actual_site_names = get_list_of_key_values(response.json(), "site_name")
+    actual_site_names.sort()
+
+    assert actual_site_names == expected_site_names
+
+
+# @pytest.mark.parametrize(
+#     "api_parameters, expected_response_length",
+#     [
+#         (
+#             {
+#                 "date_from": date_from_string_24_6_21_14_0_0,
+#                 "date_to": date_to_string_24_6_21_16_0_0,
+#                 "location_type": location_type,
+#                 "location_name": location_names_test_city_3,
+#                 "api_source": api_source_open_aq,
+#             },
+#         )
+#     ],
+# )
+# def test__different_api_source__assert_number_of_responses_is_correct(
+#     api_parameters: dict, expected_site_names: str
+# ):
+#     load_dotenv(".env-qa")
+#     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+#
+#     actual_site_names = get_list_of_key_values(response.json(), "site_name")
+#     actual_site_names.sort()
+#
+#     assert actual_site_names == expected_site_names

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -124,9 +124,16 @@ date_from_string_24_6_21_14_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 6, 21, 14, 0, 0, tzinfo=datetime.timezone.utc),
     "%Y-%m-%dT%H:%M:%SZ",
 )
+date_from_string_24_6_21_15_0_0 = format_datetime_as_string(
+    datetime.datetime(2024, 6, 21, 15, 0, 0),
+    "%Y-%m-%dT%H:%M:%SZ",
+)
 date_to_string_24_6_21_16_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 6, 21, 16, 0, 0, tzinfo=datetime.timezone.utc),
     "%Y-%m-%dT%H:%M:%SZ",
+)
+date_to_string_24_7_29_15_0_0 = format_datetime_as_string(
+    datetime.datetime(2024, 7, 29, 15, 0, 0), "%Y-%m-%dT%H:%M:%SZ"
 )
 
 # Test Setup
@@ -139,6 +146,7 @@ seed_api_test_data(
         test_city_2_site_1_2024_6_21_13_59_0,
         test_city_2_site_1_2024_6_21_14_0_0,
         test_city_3_site_1_2024_6_21_14_30_0,
+        test_city_3_site_1_2024_6_21_14_45_0,
         test_city_3_site_2_2024_6_21_15_30_0,
         test_city_1_site_1_2024_6_21_15_0_0,
         test_city_2_site_2_2024_6_21_16_0_0,
@@ -157,27 +165,165 @@ seed_api_test_data(
                 "date_to": date_to_string_24_6_21_16_0_0,
                 "location_type": location_type,
             },
-            ["Test City 1", "Test City 2", "Test City 2", "Test City 3", "Test City 3"],
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["name"],
+                test_city_2_site_1_2024_6_21_14_0_0["name"],
+                test_city_2_site_2_2024_6_21_16_0_0["name"],
+                test_city_3_site_1_2024_6_21_14_30_0["name"],
+                test_city_3_site_1_2024_6_21_14_45_0["name"],
+                test_city_3_site_2_2024_6_21_15_30_0["name"],
+            ],
         ),
-        # (
-        #     {
-        #         "date_from": date_from_string_24_6_12_14_0_0,
-        #         "date_to": date_to_string_24_6_12_16_0_0,
-        #         "location_type": location_type,
-        #     },
-        #     [],
-        # ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_15_0_0,
+                "date_to": date_to_string_24_7_29_15_0_0,
+                "location_type": location_type,
+            },
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["name"],
+                test_city_1_site_2_2024_6_21_16_1_0["name"],
+                test_city_2_site_2_2024_6_21_16_0_0["name"],
+                test_city_2_site_3_2024_7_28_9_0_0["name"],
+                test_city_3_site_2_2024_6_21_15_30_0["name"],
+            ],
+        ),
     ],
 )
-def test__different_measurement_dates__assert_location_name_filtered_appropriately(
+def test__different_measurement_dates__assert_response_location_names_are_correct(
     api_parameters: dict, expected_location_names: str
 ):
     load_dotenv(".env-qa")
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
-    actual_locations = get_list_of_key_values(response.json(), "location_name")
-    actual_locations.sort()
+    actual_location_names = get_list_of_key_values(response.json(), "location_name")
+    actual_location_names.sort()
 
-    print(actual_locations)
-    print(expected_location_names)
-    assert actual_locations == expected_location_names
+    assert actual_location_names == expected_location_names
+
+
+@pytest.mark.parametrize(
+    "api_parameters, expected_site_names",
+    [
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+            },
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["location_name"],
+                test_city_2_site_1_2024_6_21_14_0_0["location_name"],
+                test_city_2_site_2_2024_6_21_16_0_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_30_0["location_name"],
+                test_city_3_site_1_2024_6_21_14_45_0["location_name"],
+                test_city_3_site_2_2024_6_21_15_30_0["location_name"],
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_15_0_0,
+                "date_to": date_to_string_24_7_29_15_0_0,
+                "location_type": location_type,
+            },
+            [
+                test_city_1_site_1_2024_6_21_15_0_0["location_name"],
+                test_city_1_site_2_2024_6_21_16_1_0["location_name"],
+                test_city_2_site_2_2024_6_21_16_0_0["location_name"],
+                test_city_2_site_3_2024_7_28_9_0_0["location_name"],
+                test_city_3_site_2_2024_6_21_15_30_0["location_name"],
+            ],
+        ),
+    ],
+)
+def test__different_measurement_dates__assert_response_site_names_are_correct(
+    api_parameters: dict, expected_site_names: str
+):
+    load_dotenv(".env-qa")
+    response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+
+    actual_site_names = get_list_of_key_values(response.json(), "site_name")
+    actual_site_names.sort()
+
+    assert actual_site_names == expected_site_names
+
+
+@pytest.mark.parametrize(
+    "api_parameters, expected_measurement_dates",
+    [
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+            },
+            [
+                format_datetime_as_string(
+                    test_city_2_site_1_2024_6_21_14_0_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_3_site_1_2024_6_21_14_30_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_3_site_1_2024_6_21_14_45_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_1_site_1_2024_6_21_15_0_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_3_site_2_2024_6_21_15_30_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_2_site_2_2024_6_21_16_0_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+            ],
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_15_0_0,
+                "date_to": date_to_string_24_7_29_15_0_0,
+                "location_type": location_type,
+            },
+            [
+                format_datetime_as_string(
+                    test_city_1_site_1_2024_6_21_15_0_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_3_site_2_2024_6_21_15_30_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_2_site_2_2024_6_21_16_0_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_1_site_2_2024_6_21_16_1_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+                format_datetime_as_string(
+                    test_city_2_site_3_2024_7_28_9_0_0["measurement_date"],
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ),
+            ],
+        ),
+    ],
+)
+def test__different_measurement_dates__assert_response_measurement_dates_are_correct(
+    api_parameters: dict, expected_measurement_dates: str
+):
+    load_dotenv(".env-qa")
+    response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+
+    actual_measurement_dates = get_list_of_key_values(
+        response.json(), "measurement_date"
+    )
+    actual_measurement_dates.sort()
+
+    assert actual_measurement_dates == expected_measurement_dates

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -1,0 +1,183 @@
+import datetime
+import pprint
+
+import pytest
+import requests
+from dotenv import load_dotenv
+
+from system_tests.data.measurement_summary_api_test_data import (
+    create_in_situ_database_data_with_overrides,
+)
+from system_tests.utils.api_utilities import (
+    format_datetime_as_string,
+    get_list_of_key_values,
+)
+from system_tests.utils.cams_utilities import delete_database_data
+from system_tests.utils.database_utilities import seed_api_test_data
+from system_tests.utils.routes import Routes
+
+# Parameter Test Data
+test_city_1_site_1_2024_5_6_4_0_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 5, 6, 4, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 1",
+        "location_name": "Test City 1, Site 1",
+    }
+)
+
+test_city_2_site_1_2024_6_21_13_59_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 13, 59, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 2",
+        "location_name": "Test City 2, Site 1",
+    }
+)
+
+test_city_2_site_1_2024_6_21_14_0_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 14, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 2",
+        "location_name": "Test City 2, Site 1",
+    }
+)
+
+test_city_3_site_1_2024_6_21_14_30_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 14, 30, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 3",
+        "location_name": "Test City 3, Site 1",
+    }
+)
+
+test_city_3_site_1_2024_6_21_14_45_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 14, 45, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 3",
+        "location_name": "Test City 3, Site 1",
+    }
+)
+
+test_city_3_site_2_2024_6_21_15_30_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 15, 30, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 3",
+        "location_name": "Test City 3, Site 2",
+    }
+)
+
+test_city_1_site_1_2024_6_21_15_0_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 15, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 1",
+        "location_name": "Test City 1, Site 1",
+    }
+)
+
+test_city_2_site_2_2024_6_21_16_0_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 16, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 2",
+        "location_name": "Test City 2, Site 2",
+    }
+)
+
+test_city_1_site_2_2024_6_21_16_1_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 6, 21, 16, 1, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 1",
+        "location_name": "Test City 1, Site 2",
+    }
+)
+
+test_city_2_site_3_2024_7_28_9_0_0 = create_in_situ_database_data_with_overrides(
+    {
+        "measurement_date": datetime.datetime(
+            2024, 7, 28, 9, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "name": "Test City 2",
+        "location_name": "Test City 2, Site 3",
+    }
+)
+
+# API GET request setup
+base_url = Routes.measurements_api_endpoint
+location_type = "city"
+date_from_string_24_6_21_14_0_0 = format_datetime_as_string(
+    datetime.datetime(2024, 6, 21, 14, 0, 0, tzinfo=datetime.timezone.utc),
+    "%Y-%m-%dT%H:%M:%SZ",
+)
+date_to_string_24_6_21_16_0_0 = format_datetime_as_string(
+    datetime.datetime(2024, 6, 21, 16, 0, 0, tzinfo=datetime.timezone.utc),
+    "%Y-%m-%dT%H:%M:%SZ",
+)
+
+# Test Setup
+load_dotenv(".env-qa")
+delete_database_data("in_situ_data")
+seed_api_test_data(
+    "in_situ_data",
+    [
+        test_city_1_site_1_2024_5_6_4_0_0,
+        test_city_2_site_1_2024_6_21_13_59_0,
+        test_city_2_site_1_2024_6_21_14_0_0,
+        test_city_3_site_1_2024_6_21_14_30_0,
+        test_city_3_site_2_2024_6_21_15_30_0,
+        test_city_1_site_1_2024_6_21_15_0_0,
+        test_city_2_site_2_2024_6_21_16_0_0,
+        test_city_1_site_2_2024_6_21_16_1_0,
+        test_city_2_site_3_2024_7_28_9_0_0,
+    ],
+)
+
+
+@pytest.mark.parametrize(
+    "api_parameters, expected_location_names",
+    [
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+            },
+            ["Test City 1", "Test City 2", "Test City 2", "Test City 3", "Test City 3"],
+        ),
+        # (
+        #     {
+        #         "date_from": date_from_string_24_6_12_14_0_0,
+        #         "date_to": date_to_string_24_6_12_16_0_0,
+        #         "location_type": location_type,
+        #     },
+        #     [],
+        # ),
+    ],
+)
+def test__different_measurement_dates__assert_location_name_filtered_appropriately(
+    api_parameters: dict, expected_location_names: str
+):
+    load_dotenv(".env-qa")
+    response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+
+    actual_locations = get_list_of_key_values(response.json(), "location_name")
+    actual_locations.sort()
+
+    print(actual_locations)
+    print(expected_location_names)
+    assert actual_locations == expected_location_names

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -1,10 +1,7 @@
 import datetime
-import pprint
-
 import pytest
 import requests
 from dotenv import load_dotenv
-
 from system_tests.data.measurement_summary_api_test_data import (
     create_in_situ_database_data_with_overrides,
 )
@@ -197,7 +194,7 @@ seed_api_test_data(
         ),
     ],
 )
-def test__different_date_from_and_date_to_ranges__assert_response_location_names_are_correct(
+def test__date_from_and_date_to_ranges__assert_response_location_names_are_correct(
     api_parameters: dict, expected_location_names: str
 ):
     load_dotenv(".env-qa")
@@ -243,7 +240,7 @@ def test__different_date_from_and_date_to_ranges__assert_response_location_names
         ),
     ],
 )
-def test__different_date_from_and_date_to_ranges__assert_response_site_names_are_correct(
+def test__date_from_and_date_to_ranges__assert_response_site_names_are_correct(
     api_parameters: dict, expected_site_names: str
 ):
     load_dotenv(".env-qa")
@@ -322,7 +319,7 @@ def test__different_date_from_and_date_to_ranges__assert_response_site_names_are
         ),
     ],
 )
-def test__different_date_from_and_date_to_ranges__assert_response_measurement_dates_are_correct(
+def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_correct(
     api_parameters: dict, expected_measurement_dates: str
 ):
     load_dotenv(".env-qa")

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -341,7 +341,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
                 "api_source": api_source_open_aq,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["name"]],
@@ -351,7 +351,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["name"]],
         ),
@@ -360,7 +360,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
                 "api_source": api_source_open_aq,
             },
             [
@@ -374,7 +374,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
             },
             [
                 test_city_3_site_1_2024_6_21_14_30_0["name"],
@@ -387,7 +387,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -408,7 +408,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -428,7 +428,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
                 "api_source": api_source_open_aq,
             },
             [],
@@ -438,7 +438,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
             },
             [],
         ),
@@ -464,7 +464,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
                 "api_source": api_source_open_aq,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
@@ -474,7 +474,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
         ),
@@ -483,7 +483,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
                 "api_source": api_source_open_aq,
             },
             [
@@ -497,7 +497,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
             },
             [
                 test_city_3_site_1_2024_6_21_14_30_0["location_name"],
@@ -510,7 +510,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -531,7 +531,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -551,7 +551,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
                 "api_source": api_source_open_aq,
             },
             [],
@@ -561,7 +561,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
             },
             [],
         ),
@@ -587,7 +587,7 @@ def test__different_location_names__assert_response_site_names_are_correct(
                 "date_from": date_string_24_6_21_16_0_0,
                 "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -601,7 +601,7 @@ def test__different_location_names__assert_response_site_names_are_correct(
                 "date_from": date_string_24_6_21_16_0_0,
                 "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -640,7 +640,7 @@ def test__different_api_source__assert_number_of_responses_is_correct(
             "date_from": date_string_24_6_21_14_0_0,
             "date_to": date_string_24_6_21_16_0_0,
             "location_type": location_type,
-            "location_name": [
+            "location_names": [
                 location_names_test_city_1,
             ],
             "api_source": api_source_open_aq,
@@ -649,7 +649,7 @@ def test__different_api_source__assert_number_of_responses_is_correct(
             "date_from": date_string_24_6_21_14_0_0,
             "date_to": date_string_24_6_21_16_0_0,
             "location_type": location_type,
-            "location_name": [
+            "location_names": [
                 location_names_test_city_1,
             ],
         },
@@ -661,7 +661,7 @@ def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
         "date_from": date_string_24_6_21_14_0_0,
         "date_to": date_string_24_6_21_16_0_0,
         "location_type": location_type,
-        "location_name": [
+        "location_names": [
             location_names_test_city_1,
         ],
         "api_source": api_source_open_aq,

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -116,25 +116,26 @@ test_city_2_site_3_2024_7_28_9_0_0 = create_in_situ_database_data_with_overrides
         ),
         "name": "Test City 2",
         "location_name": "Test City 2, Site 3",
+        "api_source": "Test",
     }
 )
 
 # API GET request setup
 base_url = Routes.measurements_api_endpoint
 location_type = "city"
-date_from_string_24_6_21_14_0_0 = format_datetime_as_string(
+date_string_24_6_21_14_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 6, 21, 14, 0, 0, tzinfo=datetime.timezone.utc),
     "%Y-%m-%dT%H:%M:%SZ",
 )
-date_from_string_24_6_21_15_0_0 = format_datetime_as_string(
+date_string_24_6_21_15_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 6, 21, 15, 0, 0),
     "%Y-%m-%dT%H:%M:%SZ",
 )
-date_to_string_24_6_21_16_0_0 = format_datetime_as_string(
+date_string_24_6_21_16_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 6, 21, 16, 0, 0, tzinfo=datetime.timezone.utc),
     "%Y-%m-%dT%H:%M:%SZ",
 )
-date_to_string_24_7_29_15_0_0 = format_datetime_as_string(
+date_string_24_7_29_15_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 7, 29, 15, 0, 0), "%Y-%m-%dT%H:%M:%SZ"
 )
 api_source_open_aq = "OpenAQ"
@@ -167,8 +168,8 @@ seed_api_test_data(
     [
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
             },
             [
@@ -182,8 +183,8 @@ seed_api_test_data(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_15_0_0,
-                "date_to": date_to_string_24_7_29_15_0_0,
+                "date_from": date_string_24_6_21_15_0_0,
+                "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
             },
             [
@@ -213,8 +214,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_location_names
     [
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
             },
             [
@@ -228,8 +229,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_location_names
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_15_0_0,
-                "date_to": date_to_string_24_7_29_15_0_0,
+                "date_from": date_string_24_6_21_15_0_0,
+                "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
             },
             [
@@ -259,8 +260,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_site_names_are
     [
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
             },
             [
@@ -292,8 +293,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_site_names_are
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_15_0_0,
-                "date_to": date_to_string_24_7_29_15_0_0,
+                "date_from": date_string_24_6_21_15_0_0,
+                "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
             },
             [
@@ -340,8 +341,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
     [
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_1,
                 "api_source": api_source_open_aq,
@@ -350,8 +351,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_1,
             },
@@ -359,8 +360,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_3,
                 "api_source": api_source_open_aq,
@@ -373,8 +374,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_3,
             },
@@ -386,8 +387,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": [
                     location_names_test_city_1,
@@ -407,8 +408,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": [
                     location_names_test_city_1,
@@ -427,8 +428,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": ["Test City 5"],
                 "api_source": api_source_open_aq,
@@ -437,8 +438,8 @@ def test__different_date_from_and_date_to_ranges__assert_response_measurement_da
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": ["Test City 5"],
             },
@@ -463,8 +464,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
     [
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_1,
                 "api_source": api_source_open_aq,
@@ -473,8 +474,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_1,
             },
@@ -482,8 +483,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_3,
                 "api_source": api_source_open_aq,
@@ -496,8 +497,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": location_names_test_city_3,
             },
@@ -509,8 +510,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": [
                     location_names_test_city_1,
@@ -530,8 +531,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": [
                     location_names_test_city_1,
@@ -550,8 +551,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": ["Test City 5"],
                 "api_source": api_source_open_aq,
@@ -560,8 +561,8 @@ def test__different_location_names__assert_response_location_names_are_correct(
         ),
         (
             {
-                "date_from": date_from_string_24_6_21_14_0_0,
-                "date_to": date_to_string_24_6_21_16_0_0,
+                "date_from": date_string_24_6_21_14_0_0,
+                "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
                 "location_name": ["Test City 5"],
             },
@@ -581,27 +582,116 @@ def test__different_location_names__assert_response_site_names_are_correct(
     assert actual_site_names == expected_site_names
 
 
-# @pytest.mark.parametrize(
-#     "api_parameters, expected_response_length",
-#     [
-#         (
-#             {
-#                 "date_from": date_from_string_24_6_21_14_0_0,
-#                 "date_to": date_to_string_24_6_21_16_0_0,
-#                 "location_type": location_type,
-#                 "location_name": location_names_test_city_3,
-#                 "api_source": api_source_open_aq,
-#             },
-#         )
-#     ],
-# )
-# def test__different_api_source__assert_number_of_responses_is_correct(
-#     api_parameters: dict, expected_site_names: str
-# ):
-#     load_dotenv(".env-qa")
-#     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
-#
-#     actual_site_names = get_list_of_key_values(response.json(), "site_name")
-#     actual_site_names.sort()
-#
-#     assert actual_site_names == expected_site_names
+@pytest.mark.parametrize(
+    "api_parameters, expected_site_names",
+    [
+        (
+            {
+                "date_from": date_string_24_6_21_16_0_0,
+                "date_to": date_string_24_7_29_15_0_0,
+                "location_type": location_type,
+                "location_name": [
+                    location_names_test_city_1,
+                    location_names_test_city_2,
+                    location_names_test_city_3,
+                ],
+                "api_source": api_source_open_aq,
+            },
+            ["Test City 1, Site 2", "Test City 2, Site 2"],
+        ),
+        (
+            {
+                "date_from": date_string_24_6_21_16_0_0,
+                "date_to": date_string_24_7_29_15_0_0,
+                "location_type": location_type,
+                "location_name": [
+                    location_names_test_city_1,
+                    location_names_test_city_2,
+                    location_names_test_city_3,
+                ],
+                "api_source": "Test",
+            },
+            ["Test City 2, Site 3"],
+        ),
+        (
+            {
+                "date_from": date_string_24_6_21_16_0_0,
+                "date_to": date_string_24_7_29_15_0_0,
+                "location_type": location_type,
+                "api_source": "Test",
+            },
+            ["Test City 2, Site 3"],
+        ),
+    ],
+)
+def test__different_api_source__assert_number_of_responses_is_correct(
+    api_parameters: dict, expected_site_names: int
+):
+    load_dotenv(".env-qa")
+    response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+
+    actual_site_names = get_list_of_key_values(response.json(), "site_name")
+    actual_site_names.sort()
+
+    assert actual_site_names == expected_site_names
+
+
+@pytest.mark.parametrize(
+    "api_parameters",
+    [
+        {
+            "date_from": date_string_24_6_21_14_0_0,
+            "date_to": date_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "location_name": [
+                location_names_test_city_1,
+            ],
+            "api_source": api_source_open_aq,
+        },
+        {
+            "date_from": date_string_24_6_21_14_0_0,
+            "date_to": date_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "location_name": [
+                location_names_test_city_1,
+            ],
+        },
+    ],
+)
+def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
+    load_dotenv(".env-qa")
+    parameters = {
+        "date_from": date_string_24_6_21_14_0_0,
+        "date_to": date_string_24_6_21_16_0_0,
+        "location_type": location_type,
+        "location_name": [
+            location_names_test_city_1,
+        ],
+        "api_source": api_source_open_aq,
+    }
+
+    expected_response: list[dict] = [
+        {
+            "api_source": test_city_1_site_1_2024_6_21_15_0_0["api_source"],
+            "measurement_date": format_datetime_as_string(
+                test_city_1_site_1_2024_6_21_15_0_0["measurement_date"],
+                "%Y-%m-%dT%H:%M:%SZ",
+            ),
+            "location_type": test_city_1_site_1_2024_6_21_15_0_0["location_type"],
+            "location_name": test_city_1_site_1_2024_6_21_15_0_0["name"],
+            "no2": test_city_1_site_1_2024_6_21_15_0_0["no2"]["value"],
+            "o3": test_city_1_site_1_2024_6_21_15_0_0["o3"]["value"],
+            "pm2_5": test_city_1_site_1_2024_6_21_15_0_0["pm2_5"]["value"],
+            "pm10": test_city_1_site_1_2024_6_21_15_0_0["pm10"]["value"],
+            "so2": test_city_1_site_1_2024_6_21_15_0_0["so2"]["value"],
+            "entity": test_city_1_site_1_2024_6_21_15_0_0["metadata"]["entity"],
+            "sensor_type": test_city_1_site_1_2024_6_21_15_0_0["metadata"][
+                "sensor_type"
+            ],
+            "site_name": test_city_1_site_1_2024_6_21_15_0_0["location_name"],
+        }
+    ]
+
+    response = requests.request("GET", base_url, params=parameters, timeout=5.0)
+    response_json = response.json()
+    assert response_json == expected_response

--- a/air-quality-backend/system_tests/api_suite/measurements_api_validation_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_validation_tests.py
@@ -1,0 +1,103 @@
+import datetime
+import pytest
+import requests
+import random
+
+from system_tests.data.cities_data import all_cities
+from system_tests.utils.api_utilities import format_datetime_as_string
+from system_tests.utils.routes import Routes
+
+base_url = Routes.measurements_api_endpoint
+date_from_string_24_6_21_14_0_0 = format_datetime_as_string(
+    datetime.datetime(2024, 6, 21, 14, 0, 0, tzinfo=datetime.timezone.utc),
+    "%Y-%m-%dT%H:%M:%SZ",
+)
+date_to_string_24_6_21_16_0_0 = format_datetime_as_string(
+    datetime.datetime(2024, 6, 21, 16, 0, 0, tzinfo=datetime.timezone.utc),
+    "%Y-%m-%dT%H:%M:%SZ",
+)
+location_type = "city"
+location_names = random.choice(all_cities)
+api_source = "OpenAQ"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "location_names": location_names,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "location_names": location_names,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+        },
+    ],
+)
+def test__required_and_optional_parameters_provided__verify_response_status_200(
+    payload: dict,
+):
+    response = requests.request("GET", base_url, params=payload, timeout=5.0)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "date_from": "",
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": "",
+            "location_type": location_type,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": "",
+        },
+        {
+            "date_from": "",
+            "date_to": "",
+            "location_type": "",
+        },
+        {
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "location_type": location_type,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+        },
+        {},
+    ],
+)
+def test__required_parameters_missing_or_empty__verify_response_status_422(
+    payload: dict,
+):
+    response = requests.request("GET", base_url, params=payload, timeout=5.0)
+
+    assert response.status_code == 422

--- a/air-quality-backend/system_tests/api_suite/measurements_api_validation_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_validation_tests.py
@@ -64,11 +64,68 @@ def test__required_and_optional_parameters_provided__verify_response_status_200(
             "date_from": "",
             "date_to": date_to_string_24_6_21_16_0_0,
             "location_type": location_type,
+            "location_names": location_names,
+            "api_source": api_source,
+        },
+        {
+            "date_from": "",
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "api_source": api_source,
+        },
+        {
+            "date_from": "",
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "location_names": location_names,
+        },
+        {
+            "date_from": "",
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
         },
         {
             "date_from": date_from_string_24_6_21_14_0_0,
             "date_to": "",
             "location_type": location_type,
+            "location_names": location_names,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": "",
+            "location_type": location_type,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": "",
+            "location_type": location_type,
+            "location_names": location_names,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": "",
+            "location_type": location_type,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": "",
+            "location_names": location_names,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": "",
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": "",
+            "location_names": location_names,
         },
         {
             "date_from": date_from_string_24_6_21_14_0_0,
@@ -83,10 +140,58 @@ def test__required_and_optional_parameters_provided__verify_response_status_200(
         {
             "date_to": date_to_string_24_6_21_16_0_0,
             "location_type": location_type,
+            "location_names": location_names,
+            "api_source": api_source,
+        },
+        {
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "api_source": api_source,
+        },
+        {
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
+            "location_names": location_names,
+        },
+        {
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_type": location_type,
         },
         {
             "date_from": date_from_string_24_6_21_14_0_0,
             "location_type": location_type,
+            "location_names": location_names,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "location_type": location_type,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "location_type": location_type,
+            "location_names": location_names,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "location_type": location_type,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_names": location_names,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "api_source": api_source,
+        },
+        {
+            "date_from": date_from_string_24_6_21_14_0_0,
+            "date_to": date_to_string_24_6_21_16_0_0,
+            "location_names": location_names,
         },
         {
             "date_from": date_from_string_24_6_21_14_0_0,
@@ -101,3 +206,159 @@ def test__required_parameters_missing_or_empty__verify_response_status_422(
     response = requests.request("GET", base_url, params=payload, timeout=5.0)
 
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "payload, method",
+    [
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+                "api_source": api_source,
+            },
+            "POST",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+                "api_source": api_source,
+            },
+            "PUT",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+                "api_source": api_source,
+            },
+            "PATCH",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+                "api_source": api_source,
+            },
+            "DELETE",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "api_source": api_source,
+            },
+            "POST",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "api_source": api_source,
+            },
+            "PUT",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "api_source": api_source,
+            },
+            "PATCH",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "api_source": api_source,
+            },
+            "DELETE",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+            },
+            "POST",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+            },
+            "PUT",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+            },
+            "PATCH",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+                "location_names": location_names,
+            },
+            "DELETE",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+            },
+            "POST",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+            },
+            "PUT",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+            },
+            "PATCH",
+        ),
+        (
+            {
+                "date_from": date_from_string_24_6_21_14_0_0,
+                "date_to": date_to_string_24_6_21_16_0_0,
+                "location_type": location_type,
+            },
+            "DELETE",
+        ),
+    ],
+)
+def test__different_http_request_methods__verify_not_valid(method: str, payload: dict):
+    response = requests.request(method, base_url, params=payload, timeout=5.0)
+
+    assert response.status_code == 405
+    assert not isinstance(response.json(), list)

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
@@ -269,7 +269,7 @@ measurement_time_range = 90
 
 
 @pytest.mark.parametrize(
-    "api_parameters, expected_city",
+    "api_parameters, expected_city_names",
     [
         (
             {
@@ -428,22 +428,18 @@ measurement_time_range = 90
     ],
 )
 def test__different_base_times__assert_data_filtered_appropriately(
-    api_parameters: dict, expected_city: str
+    api_parameters: dict, expected_city_names: str
 ):
     load_dotenv(".env-qa")
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
     actual_locations = get_list_of_key_values(response.json(), "location_name")
     actual_locations.sort()
-    if len(actual_locations) > 0:
-        for location in actual_locations:
-            index = actual_locations.index(location)
-            assert location == expected_city[index]
-    else:
-        assert actual_locations == expected_city
+
+    assert actual_locations == expected_city_names
 
 
 @pytest.mark.parametrize(
-    "api_parameters, expected_city",
+    "api_parameters, expected_city_names",
     [
         (
             {
@@ -488,18 +484,14 @@ def test__different_base_times__assert_data_filtered_appropriately(
     ],
 )
 def test__different_measurement_time_range__assert_data_filtered_appropriately(
-    api_parameters: dict, expected_city: str
+    api_parameters: dict, expected_city_names: str
 ):
     load_dotenv(".env-qa")
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
     actual_locations = get_list_of_key_values(response.json(), "location_name")
     actual_locations.sort()
-    if len(actual_locations) > 0:
-        for location in actual_locations:
-            index = actual_locations.index(location)
-            assert location == expected_city[index]
-    else:
-        assert actual_locations == expected_city
+
+    assert actual_locations == expected_city_names
 
 
 @pytest.mark.parametrize(

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
@@ -243,7 +243,7 @@ seed_api_test_data(
 )
 
 # API GET request setup
-base_url = Routes.measurement_summary_api_url
+base_url = Routes.measurements_summary_api_endpoint
 location_type = "city"
 measurement_base_time_string_24_6_12_14_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 6, 12, 14, 0, 0, tzinfo=datetime.timezone.utc),

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
@@ -18,52 +18,52 @@ from system_tests.utils.database_utilities import seed_api_test_data, \
 from system_tests.utils.routes import Routes
 
 # Parameter Test Data
-city_1_location_1 = create_in_situ_database_data_with_overrides(
+test_city_1_site_1_2024_6_11_14_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 11, 14, 0, 0, tzinfo=datetime.timezone.utc
         ),
         "name": "Test City 1",
-        "location_name": "Test City 1, Site 1, All keys",
+        "location_name": "Test City 1, Site 1",
     }
 )
-city_2_location_1 = create_in_situ_database_data_with_overrides(
+test_city_2_site_1_2024_6_12_14_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 12, 14, 0, 0, tzinfo=datetime.timezone.utc
         ),
         "name": "Test City 2",
-        "location_name": "Test City 2, Site 1, All keys",
+        "location_name": "Test City 2, Site 1",
     }
 )
-city_2_location_2 = create_in_situ_database_data_with_overrides(
+test_city_2_site_2_2024_6_12_15_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 12, 15, 0, 0, tzinfo=datetime.timezone.utc
         ),
         "name": "Test City 2",
-        "location_name": "Test City 2, Site 2, All keys",
+        "location_name": "Test City 2, Site 2",
     }
 )
-city_3_location_1 = create_in_situ_database_data_with_overrides(
+test_city_3_site_1_2024_6_12_13_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 12, 13, 0, 0, tzinfo=datetime.timezone.utc
         ),
         "name": "Test City 3",
-        "location_name": "Test City 3, Site 1, All keys",
+        "location_name": "Test City 3, Site 1",
     }
 )
 
 # Calculation Test Data
 
-city_a_location_1 = create_in_situ_database_data_with_overrides(
+test_city_a_site_1_2024_7_20_13_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 13, 0, 0, tzinfo=datetime.timezone.utc
         ),
         "name": "Test City A",
-        "location_name": "Location 1",
+        "location_name": "Site 1",
         "no2": create_measurement_summary_database_data_pollutant_value(
             800, "µg/m³", 800, "µg/m³"
         ),
@@ -81,13 +81,13 @@ city_a_location_1 = create_in_situ_database_data_with_overrides(
         ),
     }
 )
-city_a_location_2 = create_in_situ_database_data_with_overrides(
+test_city_a_site_2_2024_7_20_14_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 14, 0, 0, tzinfo=datetime.timezone.utc
         ),
         "name": "Test City A",
-        "location_name": "Location 2",
+        "location_name": "Site 2",
         "no2": create_measurement_summary_database_data_pollutant_value(
             123, "µg/m³", 123, "µg/m³"
         ),
@@ -106,7 +106,7 @@ city_a_location_2 = create_in_situ_database_data_with_overrides(
     }
 )
 
-city_a_location_3 = create_in_situ_database_data_with_overrides(
+test_city_a_site_3_2024_7_20_15_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 15, 0, 0, tzinfo=datetime.timezone.utc
@@ -131,7 +131,7 @@ city_a_location_3 = create_in_situ_database_data_with_overrides(
     }
 )
 
-city_a_location_4 = create_in_situ_database_data_with_overrides(
+test_city_a_site_4_2024_7_20_16_0_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 16, 0, 0, tzinfo=datetime.timezone.utc
@@ -156,7 +156,7 @@ city_a_location_4 = create_in_situ_database_data_with_overrides(
     }
 )
 
-city_b_location_1 = create_in_situ_database_data_with_overrides(
+test_city_b_site_1_2024_7_20_13_30_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 13, 30, 0, tzinfo=datetime.timezone.utc
@@ -181,7 +181,7 @@ city_b_location_1 = create_in_situ_database_data_with_overrides(
     }
 )
 
-city_b_location_2 = create_in_situ_database_data_with_overrides(
+test_city_b_site_2_2024_7_20_16_30_0 = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 16, 30, 0, tzinfo=datetime.timezone.utc
@@ -207,13 +207,13 @@ city_b_location_2 = create_in_situ_database_data_with_overrides(
 )
 
 
-city_c_location_1 = create_in_situ_database_data(
+test_city_c_site_1_2024_8_20_16_30_0 = create_in_situ_database_data(
     datetime.datetime(2024, 8, 20, 16, 30, 0, tzinfo=datetime.timezone.utc),
     "Test City C",
     "Location 1",
     200,
 )
-city_c_location_2 = create_in_situ_database_data(
+test_city_c_site_2_2024_8_20_17_0_0 = create_in_situ_database_data(
     datetime.datetime(2024, 8, 20, 17, 0, 0, tzinfo=datetime.timezone.utc),
     "Test City C",
     "Location 2",
@@ -227,18 +227,18 @@ delete_database_data("in_situ_data")
 seed_api_test_data(
     "in_situ_data",
     [
-        city_1_location_1,
-        city_2_location_1,
-        city_2_location_2,
-        city_3_location_1,
-        city_a_location_1,
-        city_a_location_2,
-        city_a_location_3,
-        city_a_location_4,
-        city_b_location_1,
-        city_b_location_2,
-        city_c_location_1,
-        city_c_location_2,
+        test_city_1_site_1_2024_6_11_14_0_0,
+        test_city_2_site_1_2024_6_12_14_0_0,
+        test_city_2_site_2_2024_6_12_15_0_0,
+        test_city_3_site_1_2024_6_12_13_0_0,
+        test_city_a_site_1_2024_7_20_13_0_0,
+        test_city_a_site_2_2024_7_20_14_0_0,
+        test_city_a_site_3_2024_7_20_15_0_0,
+        test_city_a_site_4_2024_7_20_16_0_0,
+        test_city_b_site_1_2024_7_20_13_30_0,
+        test_city_b_site_2_2024_7_20_16_30_0,
+        test_city_c_site_1_2024_8_20_16_30_0,
+        test_city_c_site_2_2024_8_20_17_0_0,
     ],
 )
 
@@ -514,44 +514,44 @@ def test__different_measurement_time_range__assert_data_filtered_appropriately(
             measurement_base_time_string_24_7_20_14_0_0,
             statistics.mean(
                 [
-                    city_a_location_1["no2"]["value"],
-                    city_a_location_2["no2"]["value"],
-                    city_a_location_3["no2"]["value"],
+                    test_city_a_site_1_2024_7_20_13_0_0["no2"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["no2"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["no2"]["value"],
                 ]
             ),
-            city_b_location_1["no2"]["value"],
+            test_city_b_site_1_2024_7_20_13_30_0["no2"]["value"],
             statistics.mean(
                 [
-                    city_a_location_1["o3"]["value"],
-                    city_a_location_2["o3"]["value"],
-                    city_a_location_3["o3"]["value"],
+                    test_city_a_site_1_2024_7_20_13_0_0["o3"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["o3"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["o3"]["value"],
                 ]
             ),
-            city_b_location_1["o3"]["value"],
+            test_city_b_site_1_2024_7_20_13_30_0["o3"]["value"],
             statistics.mean(
                 [
-                    city_a_location_1["pm10"]["value"],
-                    city_a_location_2["pm10"]["value"],
-                    city_a_location_3["pm10"]["value"],
+                    test_city_a_site_1_2024_7_20_13_0_0["pm10"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["pm10"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["pm10"]["value"],
                 ]
             ),
-            city_b_location_1["pm10"]["value"],
+            test_city_b_site_1_2024_7_20_13_30_0["pm10"]["value"],
             statistics.mean(
                 [
-                    city_a_location_1["pm2_5"]["value"],
-                    city_a_location_2["pm2_5"]["value"],
-                    city_a_location_3["pm2_5"]["value"],
+                    test_city_a_site_1_2024_7_20_13_0_0["pm2_5"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["pm2_5"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["pm2_5"]["value"],
                 ]
             ),
-            city_b_location_1["pm2_5"]["value"],
+            test_city_b_site_1_2024_7_20_13_30_0["pm2_5"]["value"],
             statistics.mean(
                 [
-                    city_a_location_1["so2"]["value"],
-                    city_a_location_2["so2"]["value"],
-                    city_a_location_3["so2"]["value"],
+                    test_city_a_site_1_2024_7_20_13_0_0["so2"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["so2"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["so2"]["value"],
                 ]
             ),
-            city_b_location_1["so2"]["value"],
+            test_city_b_site_1_2024_7_20_13_30_0["so2"]["value"],
         ),
         (
             format_datetime_as_string(
@@ -560,67 +560,67 @@ def test__different_measurement_time_range__assert_data_filtered_appropriately(
             ),
             statistics.mean(
                 [
-                    city_a_location_2["no2"]["value"],
-                    city_a_location_3["no2"]["value"],
-                    city_a_location_4["no2"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["no2"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["no2"]["value"],
+                    test_city_a_site_4_2024_7_20_16_0_0["no2"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_b_location_1["no2"]["value"],
-                    city_b_location_2["no2"]["value"],
+                    test_city_b_site_1_2024_7_20_13_30_0["no2"]["value"],
+                    test_city_b_site_2_2024_7_20_16_30_0["no2"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_a_location_2["o3"]["value"],
-                    city_a_location_3["o3"]["value"],
-                    city_a_location_4["o3"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["o3"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["o3"]["value"],
+                    test_city_a_site_4_2024_7_20_16_0_0["o3"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_b_location_1["o3"]["value"],
-                    city_b_location_2["o3"]["value"],
+                    test_city_b_site_1_2024_7_20_13_30_0["o3"]["value"],
+                    test_city_b_site_2_2024_7_20_16_30_0["o3"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_a_location_2["pm10"]["value"],
-                    city_a_location_3["pm10"]["value"],
-                    city_a_location_4["pm10"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["pm10"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["pm10"]["value"],
+                    test_city_a_site_4_2024_7_20_16_0_0["pm10"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_b_location_1["pm10"]["value"],
-                    city_b_location_2["pm10"]["value"],
+                    test_city_b_site_1_2024_7_20_13_30_0["pm10"]["value"],
+                    test_city_b_site_2_2024_7_20_16_30_0["pm10"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_a_location_2["pm2_5"]["value"],
-                    city_a_location_3["pm2_5"]["value"],
-                    city_a_location_4["pm2_5"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["pm2_5"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["pm2_5"]["value"],
+                    test_city_a_site_4_2024_7_20_16_0_0["pm2_5"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_b_location_1["pm2_5"]["value"],
-                    city_b_location_2["pm2_5"]["value"],
+                    test_city_b_site_1_2024_7_20_13_30_0["pm2_5"]["value"],
+                    test_city_b_site_2_2024_7_20_16_30_0["pm2_5"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_a_location_2["so2"]["value"],
-                    city_a_location_3["so2"]["value"],
-                    city_a_location_4["so2"]["value"],
+                    test_city_a_site_2_2024_7_20_14_0_0["so2"]["value"],
+                    test_city_a_site_3_2024_7_20_15_0_0["so2"]["value"],
+                    test_city_a_site_4_2024_7_20_16_0_0["so2"]["value"],
                 ]
             ),
             statistics.mean(
                 [
-                    city_b_location_1["so2"]["value"],
-                    city_b_location_2["so2"]["value"],
+                    test_city_b_site_1_2024_7_20_13_30_0["so2"]["value"],
+                    test_city_b_site_2_2024_7_20_16_30_0["so2"]["value"],
                 ]
             ),
         ),

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_validation_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_validation_tests.py
@@ -112,5 +112,5 @@ def test__required_parameters_missing_or_empty__verify_response_status_422(
 def test__different_http_request_methods__verify_not_valid(method: str, payload: dict):
     response = requests.request(method, base_url, params=payload, timeout=5.0)
 
-    assert response.status_code == 406
+    assert response.status_code == 405
     assert not isinstance(response.json(), list)

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_validation_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_validation_tests.py
@@ -70,3 +70,47 @@ def test__required_parameters_missing_or_empty__verify_response_status_422(
     response = requests.request("GET", base_url, params=payload, timeout=5.0)
 
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "payload, method",
+    [
+        (
+            {
+                "location_type": location_type,
+                "measurement_base_time": measurement_base_time_string_24_7_20_14_0_0,
+                "measurement_time_range": measurement_time_range,
+            },
+            "POST",
+        ),
+        (
+            {
+                "location_type": location_type,
+                "measurement_base_time": measurement_base_time_string_24_7_20_14_0_0,
+                "measurement_time_range": measurement_time_range,
+            },
+            "PUT",
+        ),
+        (
+            {
+                "location_type": location_type,
+                "measurement_base_time": measurement_base_time_string_24_7_20_14_0_0,
+                "measurement_time_range": measurement_time_range,
+            },
+            "PATCH",
+        ),
+        (
+            {
+                "location_type": location_type,
+                "measurement_base_time": measurement_base_time_string_24_7_20_14_0_0,
+                "measurement_time_range": measurement_time_range,
+            },
+            "DELETE",
+        ),
+    ],
+)
+def test__different_http_request_methods__verify_not_valid(method: str, payload: dict):
+    response = requests.request(method, base_url, params=payload, timeout=5.0)
+
+    assert response.status_code == 406
+    assert not isinstance(response.json(), list)

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_validation_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_validation_tests.py
@@ -6,7 +6,7 @@ import requests
 from system_tests.utils.api_utilities import format_datetime_as_string
 from system_tests.utils.routes import Routes
 
-base_url = Routes.measurement_summary_api_url
+base_url = Routes.measurements_summary_api_endpoint
 location_type = "city"
 measurement_base_time_string_24_7_20_14_0_0 = format_datetime_as_string(
     datetime.datetime(2024, 7, 20, 14, 0, 0, tzinfo=datetime.timezone.utc),

--- a/air-quality-backend/system_tests/utils/routes.py
+++ b/air-quality-backend/system_tests/utils/routes.py
@@ -1,4 +1,5 @@
 class Routes:
-    local_base_url = "http://127.0.0.1:8000"
-    forecast_api_url = local_base_url + "/air-pollutant/forecast"
-    measurement_summary_api_url = local_base_url + "/air-pollutant/measurements/summary"
+    local_base_url = "http://127.0.0.1:8000/air-pollutant"
+    forecast_api_endpoint = local_base_url + "/forecast"
+    measurements_api_endpoint = local_base_url + "/measurements"
+    measurements_summary_api_endpoint = measurements_api_endpoint + "/summary"


### PR DESCRIPTION
### Description

- This is to test [this](https://github.com/orgs/ECMWFCode4Earth/projects/12/views/1?pane=issue&itemId=64417937) ticket
- Link to test analysis [here](https://github.com/orgs/ECMWFCode4Earth/projects/12/views/1?pane=issue&itemId=64417937)

`air-quality-backend/system_tests/utils/routes.py`
- expanded the list of endpoints and improved structure

`air-quality-backend/system_tests/api_suite/measurements_summary_api_validation_tests.py`
- added missing test for different http methods
- updated route

`air-quality-backend/system_tests/api_suite/forecast_api_validation_tests.py`
- added missing test for different http methods
- updated route

`air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py`
- updated existing test to use better assertion
- updated route

`air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py`
- updated existing test to use better assertion
- standardised test data naming
- updated route

`air-quality-backend/system_tests/api_suite/measurements_api_validation_tests.py`
- created tests verifying missine / empty parameters, and checking you can't use the wrong http request method

`air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py`
- created tests seeding the database with specific data
- `test__date_from_and_date_to_ranges__assert_response_location_names_are_correct`
- `test__date_from_and_date_to_ranges__assert_response_site_names_are_correct`
- `test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_correct`
- `test__different_location_names__assert_response_location_names_are_correct`
- `test__different_location_names__assert_response_site_names_are_correct`
- `test__different_api_source__assert_number_of_responses_is_correct`
- `test__assert_response_keys_and_values_are_correct`

