### PR TITLE
Copy poetry.lock file in dockerfiles

### DIFF
--- a/air-quality-backend/Dockerfile.api
+++ b/air-quality-backend/Dockerfile.api
@@ -6,7 +6,7 @@ RUN conda env create -f environment.yml
 
 SHELL ["conda", "run", "-n", "air-quality-backend", "/bin/bash", "-c"]
 
-COPY pyproject.toml .
+COPY pyproject.toml poetry.lock ./
 RUN poetry install
 
 COPY src/ ./src

--- a/air-quality-backend/Dockerfile.forecast
+++ b/air-quality-backend/Dockerfile.forecast
@@ -6,7 +6,7 @@ RUN conda env create -f environment.yml
 
 SHELL ["conda", "run", "-n", "air-quality-backend", "/bin/bash", "-c"]
 
-COPY pyproject.toml .
+COPY pyproject.toml poetry.lock ./
 RUN poetry install
 
 COPY src/ ./src

--- a/air-quality-backend/Dockerfile.insitu
+++ b/air-quality-backend/Dockerfile.insitu
@@ -6,7 +6,7 @@ RUN conda env create -f environment.yml
 
 SHELL ["conda", "run", "-n", "air-quality-backend", "/bin/bash", "-c"]
 
-COPY pyproject.toml .
+COPY pyproject.toml poetry.lock ./
 RUN poetry install
 
 COPY src/ ./src


### PR DESCRIPTION
There were issues with building the dockerfiles because a new version of setuptool which seems to break it.

By copying the lock files the installation doesn't need to redetermine the dependencies.