### PR TITLE
Test Automation: adding bad document API tests

### DIFF
--- a/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
@@ -218,7 +218,6 @@ def test__different_base_times__assert_correct_results_returned(
     parameters: dict,
     expected_cities: list,
 ):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -320,7 +319,6 @@ def test__different_base_times__assert_correct_results_returned(
     ],
 )
 def test__base_time_bva__assert_number_of_results(parameters: dict, expected: int):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -396,7 +394,6 @@ def test__different_valid_time_from_times__assert_correct_results(
     parameters: dict,
     expected_cities: list,
 ):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -500,7 +497,6 @@ def test__different_valid_time_from_times__assert_correct_results(
 def test__valid_time_from_bva__assert_number_of_results(
     parameters: dict, expected: int
 ):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -576,7 +572,6 @@ def test__different_valid_time_to_times__assert_correct_results(
     parameters: dict,
     expected_cities: list,
 ):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -678,7 +673,6 @@ def test__different_valid_time_to_times__assert_correct_results(
     ],
 )
 def test__valid_time_to_bva__assert_number_of_results(parameters: dict, expected: int):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -706,7 +700,6 @@ def test__valid_time_to_bva__assert_number_of_results(parameters: dict, expected
     ),
 )
 def test__results_containing_relevant_base_time(parameters: dict):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -747,7 +740,6 @@ def test__results_containing_relevant_base_time(parameters: dict):
 def test__assert_response_keys_and_values_are_correct(
     parameters: dict, expected_response: list
 ):
-    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -756,7 +748,6 @@ def test__assert_response_keys_and_values_are_correct(
 
 
 def test__invalid_document_in_database__assert_500():
-    load_dotenv()
     parameters: dict = {
         "base_time": format_datetime_as_string(
             datetime.datetime(2024, 3, 27, 0, 0, 0, tzinfo=datetime.timezone.utc),

--- a/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/forecast_api_seeded_data_tests.py
@@ -11,8 +11,10 @@ from system_tests.utils.api_utilities import (
     format_datetime_as_string,
     get_list_of_key_values,
 )
-from system_tests.utils.database_utilities import seed_api_test_data, \
-    delete_database_data
+from system_tests.utils.database_utilities import (
+    seed_api_test_data,
+    delete_database_data,
+)
 from system_tests.utils.routes import Routes
 
 # Test Data
@@ -127,7 +129,7 @@ valid_time_to_string = format_datetime_as_string(
 )
 
 # Test Setup
-load_dotenv(".env-qa")
+load_dotenv()
 delete_database_data("forecast_data")
 seed_api_test_data(
     "forecast_data",
@@ -188,7 +190,7 @@ def test__different_base_times__assert_correct_results_returned(
     parameters: dict,
     expected_cities: list,
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -290,7 +292,7 @@ def test__different_base_times__assert_correct_results_returned(
     ],
 )
 def test__base_time_bva__assert_number_of_results(parameters: dict, expected: int):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -366,7 +368,7 @@ def test__different_valid_time_from_times__assert_correct_results(
     parameters: dict,
     expected_cities: list,
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -470,7 +472,7 @@ def test__different_valid_time_from_times__assert_correct_results(
 def test__valid_time_from_bva__assert_number_of_results(
     parameters: dict, expected: int
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -546,7 +548,7 @@ def test__different_valid_time_to_times__assert_correct_results(
     parameters: dict,
     expected_cities: list,
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -648,7 +650,7 @@ def test__different_valid_time_to_times__assert_correct_results(
     ],
 )
 def test__valid_time_to_bva__assert_number_of_results(parameters: dict, expected: int):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -676,7 +678,7 @@ def test__valid_time_to_bva__assert_number_of_results(parameters: dict, expected
     ),
 )
 def test__results_containing_relevant_base_time(parameters: dict):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )
@@ -717,7 +719,7 @@ def test__results_containing_relevant_base_time(parameters: dict):
 def test__assert_response_keys_and_values_are_correct(
     parameters: dict, expected_response: list
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request(
         "GET", base_url, headers=headers, params=parameters, timeout=5.0
     )

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -391,7 +391,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
                 "api_source": api_source_open_aq,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["name"]],
@@ -401,7 +401,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["name"]],
         ),
@@ -410,7 +410,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
                 "api_source": api_source_open_aq,
             },
             [
@@ -424,7 +424,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
             },
             [
                 test_city_3_site_1_2024_6_21_14_30_0["name"],
@@ -437,7 +437,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -458,7 +458,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -478,7 +478,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
                 "api_source": api_source_open_aq,
             },
             [],
@@ -488,7 +488,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
             },
             [],
         ),
@@ -514,7 +514,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
                 "api_source": api_source_open_aq,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
@@ -524,7 +524,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_1,
+                "location_names": location_names_test_city_1,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
         ),
@@ -533,7 +533,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
                 "api_source": api_source_open_aq,
             },
             [
@@ -547,7 +547,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": location_names_test_city_3,
+                "location_names": location_names_test_city_3,
             },
             [
                 test_city_3_site_1_2024_6_21_14_30_0["location_name"],
@@ -560,7 +560,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -581,7 +581,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -601,7 +601,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
                 "api_source": api_source_open_aq,
             },
             [],
@@ -611,7 +611,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_name": ["Test City 5"],
+                "location_names": ["Test City 5"],
             },
             [],
         ),
@@ -637,7 +637,7 @@ def test__different_location_names__assert_response_site_names_are_correct(
                 "date_from": date_string_24_6_21_16_0_0,
                 "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -651,7 +651,7 @@ def test__different_location_names__assert_response_site_names_are_correct(
                 "date_from": date_string_24_6_21_16_0_0,
                 "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
-                "location_name": [
+                "location_names": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -690,7 +690,7 @@ def test__different_api_source__assert_number_of_responses_is_correct(
             "date_from": date_string_24_6_21_14_0_0,
             "date_to": date_string_24_6_21_16_0_0,
             "location_type": location_type,
-            "location_name": [
+            "location_names": [
                 location_names_test_city_1,
             ],
             "api_source": api_source_open_aq,
@@ -699,7 +699,7 @@ def test__different_api_source__assert_number_of_responses_is_correct(
             "date_from": date_string_24_6_21_14_0_0,
             "date_to": date_string_24_6_21_16_0_0,
             "location_type": location_type,
-            "location_name": [
+            "location_names": [
                 location_names_test_city_1,
             ],
         },
@@ -711,7 +711,7 @@ def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
         "date_from": date_string_24_6_21_14_0_0,
         "date_to": date_string_24_6_21_16_0_0,
         "location_type": location_type,
-        "location_name": [
+        "location_names": [
             location_names_test_city_1,
         ],
         "api_source": api_source_open_aq,

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -141,7 +141,7 @@ location_names_test_city_2 = "Test City 2"
 location_names_test_city_3 = "Test City 3"
 
 # Test Setup
-load_dotenv(".env-qa")
+load_dotenv()
 delete_database_data("in_situ_data")
 seed_api_test_data(
     "in_situ_data",
@@ -197,7 +197,7 @@ seed_api_test_data(
 def test__date_from_and_date_to_ranges__assert_response_location_names_are_correct(
     api_parameters: dict, expected_location_names: str
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_location_names = get_list_of_key_values(response.json(), "location_name")
@@ -243,7 +243,7 @@ def test__date_from_and_date_to_ranges__assert_response_location_names_are_corre
 def test__date_from_and_date_to_ranges__assert_response_site_names_are_correct(
     api_parameters: dict, expected_site_names: str
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_site_names = get_list_of_key_values(response.json(), "site_name")
@@ -322,7 +322,7 @@ def test__date_from_and_date_to_ranges__assert_response_site_names_are_correct(
 def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_correct(
     api_parameters: dict, expected_measurement_dates: str
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_measurement_dates = get_list_of_key_values(
@@ -447,7 +447,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
 def test__different_location_names__assert_response_location_names_are_correct(
     api_parameters: dict, expected_location_names: str
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_location_names = get_list_of_key_values(response.json(), "location_name")
@@ -570,7 +570,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
 def test__different_location_names__assert_response_site_names_are_correct(
     api_parameters: dict, expected_site_names: str
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_site_names = get_list_of_key_values(response.json(), "site_name")
@@ -624,7 +624,7 @@ def test__different_location_names__assert_response_site_names_are_correct(
 def test__different_api_source__assert_number_of_responses_is_correct(
     api_parameters: dict, expected_site_names: int
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_site_names = get_list_of_key_values(response.json(), "site_name")
@@ -656,7 +656,7 @@ def test__different_api_source__assert_number_of_responses_is_correct(
     ],
 )
 def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
-    load_dotenv(".env-qa")
+    load_dotenv()
     parameters = {
         "date_from": date_string_24_6_21_14_0_0,
         "date_to": date_string_24_6_21_16_0_0,

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -4,6 +4,9 @@ import requests
 from dotenv import load_dotenv
 from system_tests.data.measurement_summary_api_test_data import (
     create_in_situ_database_data_with_overrides,
+    create_location_values,
+    create_metadata_values,
+    create_measurement_summary_database_data_pollutant_value,
 )
 from system_tests.utils.api_utilities import (
     format_datetime_as_string,
@@ -16,7 +19,7 @@ from system_tests.utils.database_utilities import (
 from system_tests.utils.routes import Routes
 
 # Parameter Test Data
-test_city_1_site_1_2024_5_6_4_0_0 = create_in_situ_database_data_with_overrides(
+test_city_1_site_1_2024_5_6_4_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 5, 6, 4, 0, 0, tzinfo=datetime.timezone.utc
@@ -26,17 +29,19 @@ test_city_1_site_1_2024_5_6_4_0_0 = create_in_situ_database_data_with_overrides(
     }
 )
 
-test_city_2_site_1_2024_6_21_13_59_0 = create_in_situ_database_data_with_overrides(
-    {
-        "measurement_date": datetime.datetime(
-            2024, 6, 21, 13, 59, 0, tzinfo=datetime.timezone.utc
-        ),
-        "name": "Test City 2",
-        "location_name": "Test City 2, Site 1",
-    }
+test_city_2_site_1_2024_6_21_13_59_0: dict = (
+    create_in_situ_database_data_with_overrides(
+        {
+            "measurement_date": datetime.datetime(
+                2024, 6, 21, 13, 59, 0, tzinfo=datetime.timezone.utc
+            ),
+            "name": "Test City 2",
+            "location_name": "Test City 2, Site 1",
+        }
+    )
 )
 
-test_city_2_site_1_2024_6_21_14_0_0 = create_in_situ_database_data_with_overrides(
+test_city_2_site_1_2024_6_21_14_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 21, 14, 0, 0, tzinfo=datetime.timezone.utc
@@ -46,37 +51,43 @@ test_city_2_site_1_2024_6_21_14_0_0 = create_in_situ_database_data_with_override
     }
 )
 
-test_city_3_site_1_2024_6_21_14_30_0 = create_in_situ_database_data_with_overrides(
-    {
-        "measurement_date": datetime.datetime(
-            2024, 6, 21, 14, 30, 0, tzinfo=datetime.timezone.utc
-        ),
-        "name": "Test City 3",
-        "location_name": "Test City 3, Site 1",
-    }
+test_city_3_site_1_2024_6_21_14_30_0: dict = (
+    create_in_situ_database_data_with_overrides(
+        {
+            "measurement_date": datetime.datetime(
+                2024, 6, 21, 14, 30, 0, tzinfo=datetime.timezone.utc
+            ),
+            "name": "Test City 3",
+            "location_name": "Test City 3, Site 1",
+        }
+    )
 )
 
-test_city_3_site_1_2024_6_21_14_45_0 = create_in_situ_database_data_with_overrides(
-    {
-        "measurement_date": datetime.datetime(
-            2024, 6, 21, 14, 45, 0, tzinfo=datetime.timezone.utc
-        ),
-        "name": "Test City 3",
-        "location_name": "Test City 3, Site 1",
-    }
+test_city_3_site_1_2024_6_21_14_45_0: dict = (
+    create_in_situ_database_data_with_overrides(
+        {
+            "measurement_date": datetime.datetime(
+                2024, 6, 21, 14, 45, 0, tzinfo=datetime.timezone.utc
+            ),
+            "name": "Test City 3",
+            "location_name": "Test City 3, Site 1",
+        }
+    )
 )
 
-test_city_3_site_2_2024_6_21_15_30_0 = create_in_situ_database_data_with_overrides(
-    {
-        "measurement_date": datetime.datetime(
-            2024, 6, 21, 15, 30, 0, tzinfo=datetime.timezone.utc
-        ),
-        "name": "Test City 3",
-        "location_name": "Test City 3, Site 2",
-    }
+test_city_3_site_2_2024_6_21_15_30_0: dict = (
+    create_in_situ_database_data_with_overrides(
+        {
+            "measurement_date": datetime.datetime(
+                2024, 6, 21, 15, 30, 0, tzinfo=datetime.timezone.utc
+            ),
+            "name": "Test City 3",
+            "location_name": "Test City 3, Site 2",
+        }
+    )
 )
 
-test_city_1_site_1_2024_6_21_15_0_0 = create_in_situ_database_data_with_overrides(
+test_city_1_site_1_2024_6_21_15_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 21, 15, 0, 0, tzinfo=datetime.timezone.utc
@@ -86,7 +97,7 @@ test_city_1_site_1_2024_6_21_15_0_0 = create_in_situ_database_data_with_override
     }
 )
 
-test_city_2_site_2_2024_6_21_16_0_0 = create_in_situ_database_data_with_overrides(
+test_city_2_site_2_2024_6_21_16_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 21, 16, 0, 0, tzinfo=datetime.timezone.utc
@@ -96,7 +107,7 @@ test_city_2_site_2_2024_6_21_16_0_0 = create_in_situ_database_data_with_override
     }
 )
 
-test_city_1_site_2_2024_6_21_16_1_0 = create_in_situ_database_data_with_overrides(
+test_city_1_site_2_2024_6_21_16_1_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 21, 16, 1, 0, tzinfo=datetime.timezone.utc
@@ -106,7 +117,7 @@ test_city_1_site_2_2024_6_21_16_1_0 = create_in_situ_database_data_with_override
     }
 )
 
-test_city_2_site_3_2024_7_28_9_0_0 = create_in_situ_database_data_with_overrides(
+test_city_2_site_3_2024_7_28_9_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 28, 9, 0, 0, tzinfo=datetime.timezone.utc
@@ -116,6 +127,44 @@ test_city_2_site_3_2024_7_28_9_0_0 = create_in_situ_database_data_with_overrides
         "api_source": "Test",
     }
 )
+
+invalid_in_situ_document: dict = {
+    "measurement_date": datetime.datetime(
+        2024, 1, 25, 8, 0, 0, tzinfo=datetime.timezone.utc
+    ),
+    "name": -7,
+    "location_name": "Test In Situ Broken",
+    "api_source": "OpenAQ",
+    "created_time": datetime.datetime(
+        2024, 1, 25, 8, 0, 0, tzinfo=datetime.timezone.utc
+    ),
+    "last_modified_time": datetime.datetime(
+        2024, 1, 25, 8, 0, 0, tzinfo=datetime.timezone.utc
+    ),
+    "location": create_location_values("point", [54.433746, 24.424399]),
+    "location_type": "city",
+    "metadata": create_metadata_values(
+        "Governmental Organization",
+        "reference grade",
+        100109.546875,
+        314.317138671875,
+    ),
+    "no2": create_measurement_summary_database_data_pollutant_value(
+        None, "µg/m³", None, "µg/m³"
+    ),
+    "o3": create_measurement_summary_database_data_pollutant_value(
+        -48, "µg/m³", -48, "µg/m³"
+    ),
+    "pm2_5": create_measurement_summary_database_data_pollutant_value(
+        2345723487589, "µg/m³", 2345723487589, "µg/m³"
+    ),
+    "pm10": create_measurement_summary_database_data_pollutant_value(
+        0.7, "µg/m³", 0.7, "µg/m³"
+    ),
+    "so2": create_measurement_summary_database_data_pollutant_value(
+        None, "µg/m³", None, "µg/m³"
+    ),
+}
 
 # API GET request setup
 base_url = Routes.measurements_api_endpoint
@@ -156,6 +205,7 @@ seed_api_test_data(
         test_city_2_site_2_2024_6_21_16_0_0,
         test_city_1_site_2_2024_6_21_16_1_0,
         test_city_2_site_3_2024_7_28_9_0_0,
+        invalid_in_situ_document,
     ],
 )
 
@@ -341,7 +391,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_1,
+                "location_name": location_names_test_city_1,
                 "api_source": api_source_open_aq,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["name"]],
@@ -351,7 +401,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_1,
+                "location_name": location_names_test_city_1,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["name"]],
         ),
@@ -360,7 +410,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_3,
+                "location_name": location_names_test_city_3,
                 "api_source": api_source_open_aq,
             },
             [
@@ -374,7 +424,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_3,
+                "location_name": location_names_test_city_3,
             },
             [
                 test_city_3_site_1_2024_6_21_14_30_0["name"],
@@ -387,7 +437,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": [
+                "location_name": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -408,7 +458,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": [
+                "location_name": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -428,7 +478,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": ["Test City 5"],
+                "location_name": ["Test City 5"],
                 "api_source": api_source_open_aq,
             },
             [],
@@ -438,7 +488,7 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": ["Test City 5"],
+                "location_name": ["Test City 5"],
             },
             [],
         ),
@@ -464,7 +514,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_1,
+                "location_name": location_names_test_city_1,
                 "api_source": api_source_open_aq,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
@@ -474,7 +524,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_1,
+                "location_name": location_names_test_city_1,
             },
             [test_city_1_site_1_2024_6_21_15_0_0["location_name"]],
         ),
@@ -483,7 +533,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_3,
+                "location_name": location_names_test_city_3,
                 "api_source": api_source_open_aq,
             },
             [
@@ -497,7 +547,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": location_names_test_city_3,
+                "location_name": location_names_test_city_3,
             },
             [
                 test_city_3_site_1_2024_6_21_14_30_0["location_name"],
@@ -510,7 +560,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": [
+                "location_name": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -531,7 +581,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": [
+                "location_name": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -551,7 +601,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": ["Test City 5"],
+                "location_name": ["Test City 5"],
                 "api_source": api_source_open_aq,
             },
             [],
@@ -561,7 +611,7 @@ def test__different_location_names__assert_response_location_names_are_correct(
                 "date_from": date_string_24_6_21_14_0_0,
                 "date_to": date_string_24_6_21_16_0_0,
                 "location_type": location_type,
-                "location_names": ["Test City 5"],
+                "location_name": ["Test City 5"],
             },
             [],
         ),
@@ -587,7 +637,7 @@ def test__different_location_names__assert_response_site_names_are_correct(
                 "date_from": date_string_24_6_21_16_0_0,
                 "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
-                "location_names": [
+                "location_name": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -601,7 +651,7 @@ def test__different_location_names__assert_response_site_names_are_correct(
                 "date_from": date_string_24_6_21_16_0_0,
                 "date_to": date_string_24_7_29_15_0_0,
                 "location_type": location_type,
-                "location_names": [
+                "location_name": [
                     location_names_test_city_1,
                     location_names_test_city_2,
                     location_names_test_city_3,
@@ -640,7 +690,7 @@ def test__different_api_source__assert_number_of_responses_is_correct(
             "date_from": date_string_24_6_21_14_0_0,
             "date_to": date_string_24_6_21_16_0_0,
             "location_type": location_type,
-            "location_names": [
+            "location_name": [
                 location_names_test_city_1,
             ],
             "api_source": api_source_open_aq,
@@ -649,7 +699,7 @@ def test__different_api_source__assert_number_of_responses_is_correct(
             "date_from": date_string_24_6_21_14_0_0,
             "date_to": date_string_24_6_21_16_0_0,
             "location_type": location_type,
-            "location_names": [
+            "location_name": [
                 location_names_test_city_1,
             ],
         },
@@ -661,7 +711,7 @@ def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
         "date_from": date_string_24_6_21_14_0_0,
         "date_to": date_string_24_6_21_16_0_0,
         "location_type": location_type,
-        "location_names": [
+        "location_name": [
             location_names_test_city_1,
         ],
         "api_source": api_source_open_aq,
@@ -692,3 +742,18 @@ def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
     response = requests.request("GET", base_url, params=parameters, timeout=5.0)
     response_json = response.json()
     assert response_json == expected_response
+
+
+def test__invalid_document_in_database__assert_500():
+    load_dotenv()
+    parameters: dict = {
+        "date_from": datetime.datetime(
+            2024, 1, 25, 7, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "date_to": datetime.datetime(
+            2024, 1, 25, 9, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "location_type": location_type,
+    }
+    response = requests.request("GET", base_url, params=parameters, timeout=5.0)
+    assert response.status_code == 500

--- a/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_api_seeded_data_tests.py
@@ -247,7 +247,6 @@ seed_api_test_data(
 def test__date_from_and_date_to_ranges__assert_response_location_names_are_correct(
     api_parameters: dict, expected_location_names: str
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_location_names = get_list_of_key_values(response.json(), "location_name")
@@ -293,7 +292,6 @@ def test__date_from_and_date_to_ranges__assert_response_location_names_are_corre
 def test__date_from_and_date_to_ranges__assert_response_site_names_are_correct(
     api_parameters: dict, expected_site_names: str
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_site_names = get_list_of_key_values(response.json(), "site_name")
@@ -372,7 +370,6 @@ def test__date_from_and_date_to_ranges__assert_response_site_names_are_correct(
 def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_correct(
     api_parameters: dict, expected_measurement_dates: str
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_measurement_dates = get_list_of_key_values(
@@ -497,7 +494,6 @@ def test__date_from_and_date_to_ranges__assert_response_measurement_dates_are_co
 def test__different_location_names__assert_response_location_names_are_correct(
     api_parameters: dict, expected_location_names: str
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_location_names = get_list_of_key_values(response.json(), "location_name")
@@ -620,7 +616,6 @@ def test__different_location_names__assert_response_location_names_are_correct(
 def test__different_location_names__assert_response_site_names_are_correct(
     api_parameters: dict, expected_site_names: str
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_site_names = get_list_of_key_values(response.json(), "site_name")
@@ -674,7 +669,6 @@ def test__different_location_names__assert_response_site_names_are_correct(
 def test__different_api_source__assert_number_of_responses_is_correct(
     api_parameters: dict, expected_site_names: int
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
 
     actual_site_names = get_list_of_key_values(response.json(), "site_name")
@@ -706,7 +700,6 @@ def test__different_api_source__assert_number_of_responses_is_correct(
     ],
 )
 def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
-    load_dotenv()
     parameters = {
         "date_from": date_string_24_6_21_14_0_0,
         "date_to": date_string_24_6_21_16_0_0,
@@ -745,7 +738,6 @@ def test__assert_response_keys_and_values_are_correct(api_parameters: dict):
 
 
 def test__invalid_document_in_database__assert_500():
-    load_dotenv()
     parameters: dict = {
         "date_from": datetime.datetime(
             2024, 1, 25, 7, 0, 0, tzinfo=datetime.timezone.utc

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
@@ -13,8 +13,10 @@ from system_tests.utils.api_utilities import (
     format_datetime_as_string,
     get_list_of_key_values,
 )
-from system_tests.utils.database_utilities import seed_api_test_data, \
-    delete_database_data
+from system_tests.utils.database_utilities import (
+    seed_api_test_data,
+    delete_database_data,
+)
 from system_tests.utils.routes import Routes
 
 # Parameter Test Data
@@ -222,7 +224,7 @@ test_city_c_site_2_2024_8_20_17_0_0 = create_in_situ_database_data(
 
 
 # Test Setup
-load_dotenv(".env-qa")
+load_dotenv()
 delete_database_data("in_situ_data")
 seed_api_test_data(
     "in_situ_data",
@@ -430,7 +432,7 @@ measurement_time_range = 90
 def test__different_base_times__assert_data_filtered_appropriately(
     api_parameters: dict, expected_city_names: str
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
     actual_locations = get_list_of_key_values(response.json(), "location_name")
     actual_locations.sort()
@@ -486,7 +488,7 @@ def test__different_base_times__assert_data_filtered_appropriately(
 def test__different_measurement_time_range__assert_data_filtered_appropriately(
     api_parameters: dict, expected_city_names: str
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
     actual_locations = get_list_of_key_values(response.json(), "location_name")
     actual_locations.sort()
@@ -631,7 +633,7 @@ def test__response_contains_correct_pollutant_mean_values(
     expected_test_city_a_so2_mean: float,
     expected_test_city_b_so2_mean: float,
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,
@@ -696,7 +698,7 @@ def test__response_contains_correct_pollutant_mean_aqi_level(
     expected_test_city_a_so2_mean_aqi_level: int,
     expected_test_city_b_so2_mean_aqi_level: int,
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,
@@ -781,7 +783,7 @@ def test__response_contains_correct_mean_overall_aqi_level(
     expected_test_city_b_mean_overall_aqi: float | None,
     expected_test_city_c_mean_overall_aqi: float | None,
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,
@@ -827,7 +829,7 @@ def test__response_contains_correct_mean_overall_aqi_level(
 def test__check_measurement_base_time_in_response_is_correct(
     test_measurement_base_time_string: str,
 ):
-    load_dotenv(".env-qa")
+    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
@@ -476,7 +476,6 @@ measurement_time_range = 90
 def test__different_base_times__assert_data_filtered_appropriately(
     api_parameters: dict, expected_city_names: str
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
     actual_locations = get_list_of_key_values(response.json(), "location_name")
     actual_locations.sort()
@@ -532,7 +531,6 @@ def test__different_base_times__assert_data_filtered_appropriately(
 def test__different_measurement_time_range__assert_data_filtered_appropriately(
     api_parameters: dict, expected_city_names: str
 ):
-    load_dotenv()
     response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
     actual_locations = get_list_of_key_values(response.json(), "location_name")
     actual_locations.sort()
@@ -677,7 +675,6 @@ def test__response_contains_correct_pollutant_mean_values(
     expected_test_city_a_so2_mean: float,
     expected_test_city_b_so2_mean: float,
 ):
-    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,
@@ -742,7 +739,6 @@ def test__response_contains_correct_pollutant_mean_aqi_level(
     expected_test_city_a_so2_mean_aqi_level: int,
     expected_test_city_b_so2_mean_aqi_level: int,
 ):
-    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,
@@ -827,7 +823,6 @@ def test__response_contains_correct_mean_overall_aqi_level(
     expected_test_city_b_mean_overall_aqi: float | None,
     expected_test_city_c_mean_overall_aqi: float | None,
 ):
-    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,
@@ -873,7 +868,6 @@ def test__response_contains_correct_mean_overall_aqi_level(
 def test__check_measurement_base_time_in_response_is_correct(
     test_measurement_base_time_string: str,
 ):
-    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": test_measurement_base_time_string,
@@ -890,7 +884,6 @@ def test__check_measurement_base_time_in_response_is_correct(
 
 
 def test__invalid_document_in_database__assert_500():
-    load_dotenv()
     api_parameters: dict = {
         "location_type": location_type,
         "measurement_base_time": datetime.datetime(

--- a/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
+++ b/air-quality-backend/system_tests/api_suite/measurements_summary_api_seeded_data_tests.py
@@ -8,6 +8,8 @@ from system_tests.data.measurement_summary_api_test_data import (
     create_in_situ_database_data_with_overrides,
     create_in_situ_database_data,
     create_measurement_summary_database_data_pollutant_value,
+    create_location_values,
+    create_metadata_values,
 )
 from system_tests.utils.api_utilities import (
     format_datetime_as_string,
@@ -20,7 +22,7 @@ from system_tests.utils.database_utilities import (
 from system_tests.utils.routes import Routes
 
 # Parameter Test Data
-test_city_1_site_1_2024_6_11_14_0_0 = create_in_situ_database_data_with_overrides(
+test_city_1_site_1_2024_6_11_14_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 11, 14, 0, 0, tzinfo=datetime.timezone.utc
@@ -29,7 +31,7 @@ test_city_1_site_1_2024_6_11_14_0_0 = create_in_situ_database_data_with_override
         "location_name": "Test City 1, Site 1",
     }
 )
-test_city_2_site_1_2024_6_12_14_0_0 = create_in_situ_database_data_with_overrides(
+test_city_2_site_1_2024_6_12_14_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 12, 14, 0, 0, tzinfo=datetime.timezone.utc
@@ -38,7 +40,7 @@ test_city_2_site_1_2024_6_12_14_0_0 = create_in_situ_database_data_with_override
         "location_name": "Test City 2, Site 1",
     }
 )
-test_city_2_site_2_2024_6_12_15_0_0 = create_in_situ_database_data_with_overrides(
+test_city_2_site_2_2024_6_12_15_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 12, 15, 0, 0, tzinfo=datetime.timezone.utc
@@ -47,7 +49,7 @@ test_city_2_site_2_2024_6_12_15_0_0 = create_in_situ_database_data_with_override
         "location_name": "Test City 2, Site 2",
     }
 )
-test_city_3_site_1_2024_6_12_13_0_0 = create_in_situ_database_data_with_overrides(
+test_city_3_site_1_2024_6_12_13_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 6, 12, 13, 0, 0, tzinfo=datetime.timezone.utc
@@ -59,7 +61,7 @@ test_city_3_site_1_2024_6_12_13_0_0 = create_in_situ_database_data_with_override
 
 # Calculation Test Data
 
-test_city_a_site_1_2024_7_20_13_0_0 = create_in_situ_database_data_with_overrides(
+test_city_a_site_1_2024_7_20_13_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 13, 0, 0, tzinfo=datetime.timezone.utc
@@ -83,7 +85,7 @@ test_city_a_site_1_2024_7_20_13_0_0 = create_in_situ_database_data_with_override
         ),
     }
 )
-test_city_a_site_2_2024_7_20_14_0_0 = create_in_situ_database_data_with_overrides(
+test_city_a_site_2_2024_7_20_14_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 14, 0, 0, tzinfo=datetime.timezone.utc
@@ -108,7 +110,7 @@ test_city_a_site_2_2024_7_20_14_0_0 = create_in_situ_database_data_with_override
     }
 )
 
-test_city_a_site_3_2024_7_20_15_0_0 = create_in_situ_database_data_with_overrides(
+test_city_a_site_3_2024_7_20_15_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 15, 0, 0, tzinfo=datetime.timezone.utc
@@ -133,7 +135,7 @@ test_city_a_site_3_2024_7_20_15_0_0 = create_in_situ_database_data_with_override
     }
 )
 
-test_city_a_site_4_2024_7_20_16_0_0 = create_in_situ_database_data_with_overrides(
+test_city_a_site_4_2024_7_20_16_0_0: dict = create_in_situ_database_data_with_overrides(
     {
         "measurement_date": datetime.datetime(
             2024, 7, 20, 16, 0, 0, tzinfo=datetime.timezone.utc
@@ -158,69 +160,110 @@ test_city_a_site_4_2024_7_20_16_0_0 = create_in_situ_database_data_with_override
     }
 )
 
-test_city_b_site_1_2024_7_20_13_30_0 = create_in_situ_database_data_with_overrides(
-    {
-        "measurement_date": datetime.datetime(
-            2024, 7, 20, 13, 30, 0, tzinfo=datetime.timezone.utc
-        ),
-        "name": "Test City B",
-        "location_name": "Location 1",
-        "no2": create_measurement_summary_database_data_pollutant_value(
-            400, "µg/m³", 400, "µg/m³"
-        ),
-        "o3": create_measurement_summary_database_data_pollutant_value(
-            400, "µg/m³", 400, "µg/m³"
-        ),
-        "pm2_5": create_measurement_summary_database_data_pollutant_value(
-            101, "µg/m³", 101, "µg/m³"
-        ),
-        "pm10": create_measurement_summary_database_data_pollutant_value(
-            101, "µg/m³", 101, "µg/m³"
-        ),
-        "so2": create_measurement_summary_database_data_pollutant_value(
-            400, "µg/m³", 400, "µg/m³"
-        ),
-    }
+test_city_b_site_1_2024_7_20_13_30_0: dict = (
+    create_in_situ_database_data_with_overrides(
+        {
+            "measurement_date": datetime.datetime(
+                2024, 7, 20, 13, 30, 0, tzinfo=datetime.timezone.utc
+            ),
+            "name": "Test City B",
+            "location_name": "Location 1",
+            "no2": create_measurement_summary_database_data_pollutant_value(
+                400, "µg/m³", 400, "µg/m³"
+            ),
+            "o3": create_measurement_summary_database_data_pollutant_value(
+                400, "µg/m³", 400, "µg/m³"
+            ),
+            "pm2_5": create_measurement_summary_database_data_pollutant_value(
+                101, "µg/m³", 101, "µg/m³"
+            ),
+            "pm10": create_measurement_summary_database_data_pollutant_value(
+                101, "µg/m³", 101, "µg/m³"
+            ),
+            "so2": create_measurement_summary_database_data_pollutant_value(
+                400, "µg/m³", 400, "µg/m³"
+            ),
+        }
+    )
 )
 
-test_city_b_site_2_2024_7_20_16_30_0 = create_in_situ_database_data_with_overrides(
-    {
-        "measurement_date": datetime.datetime(
-            2024, 7, 20, 16, 30, 0, tzinfo=datetime.timezone.utc
-        ),
-        "name": "Test City B",
-        "location_name": "Location 2",
-        "no2": create_measurement_summary_database_data_pollutant_value(
-            200, "µg/m³", 200, "µg/m³"
-        ),
-        "o3": create_measurement_summary_database_data_pollutant_value(
-            200, "µg/m³", 200, "µg/m³"
-        ),
-        "pm2_5": create_measurement_summary_database_data_pollutant_value(
-            2, "µg/m³", 2, "µg/m³"
-        ),
-        "pm10": create_measurement_summary_database_data_pollutant_value(
-            2, "µg/m³", 2, "µg/m³"
-        ),
-        "so2": create_measurement_summary_database_data_pollutant_value(
-            200, "µg/m³", 200, "µg/m³"
-        ),
-    }
+test_city_b_site_2_2024_7_20_16_30_0: dict = (
+    create_in_situ_database_data_with_overrides(
+        {
+            "measurement_date": datetime.datetime(
+                2024, 7, 20, 16, 30, 0, tzinfo=datetime.timezone.utc
+            ),
+            "name": "Test City B",
+            "location_name": "Location 2",
+            "no2": create_measurement_summary_database_data_pollutant_value(
+                200, "µg/m³", 200, "µg/m³"
+            ),
+            "o3": create_measurement_summary_database_data_pollutant_value(
+                200, "µg/m³", 200, "µg/m³"
+            ),
+            "pm2_5": create_measurement_summary_database_data_pollutant_value(
+                2, "µg/m³", 2, "µg/m³"
+            ),
+            "pm10": create_measurement_summary_database_data_pollutant_value(
+                2, "µg/m³", 2, "µg/m³"
+            ),
+            "so2": create_measurement_summary_database_data_pollutant_value(
+                200, "µg/m³", 200, "µg/m³"
+            ),
+        }
+    )
 )
 
 
-test_city_c_site_1_2024_8_20_16_30_0 = create_in_situ_database_data(
+test_city_c_site_1_2024_8_20_16_30_0: dict = create_in_situ_database_data(
     datetime.datetime(2024, 8, 20, 16, 30, 0, tzinfo=datetime.timezone.utc),
     "Test City C",
     "Location 1",
     200,
 )
-test_city_c_site_2_2024_8_20_17_0_0 = create_in_situ_database_data(
+test_city_c_site_2_2024_8_20_17_0_0: dict = create_in_situ_database_data(
     datetime.datetime(2024, 8, 20, 17, 0, 0, tzinfo=datetime.timezone.utc),
     "Test City C",
     "Location 2",
     100,
 )
+invalid_in_situ_document: dict = {
+    "measurement_date": datetime.datetime(
+        2024, 1, 25, 8, 0, 0, tzinfo=datetime.timezone.utc
+    ),
+    "name": -7,
+    "location_name": "Test In Situ Broken",
+    "api_source": "OpenAQ",
+    "created_time": datetime.datetime(
+        2024, 1, 25, 8, 0, 0, tzinfo=datetime.timezone.utc
+    ),
+    "last_modified_time": datetime.datetime(
+        2024, 1, 25, 8, 0, 0, tzinfo=datetime.timezone.utc
+    ),
+    "location": create_location_values("point", [54.433746, 24.424399]),
+    "location_type": "city",
+    "metadata": create_metadata_values(
+        "Governmental Organization",
+        "reference grade",
+        100109.546875,
+        314.317138671875,
+    ),
+    "no2": create_measurement_summary_database_data_pollutant_value(
+        None, "µg/m³", None, "µg/m³"
+    ),
+    "o3": create_measurement_summary_database_data_pollutant_value(
+        -48, "µg/m³", -48, "µg/m³"
+    ),
+    "pm2_5": create_measurement_summary_database_data_pollutant_value(
+        2345723487589, "µg/m³", 2345723487589, "µg/m³"
+    ),
+    "pm10": create_measurement_summary_database_data_pollutant_value(
+        0.7, "µg/m³", 0.7, "µg/m³"
+    ),
+    "so2": create_measurement_summary_database_data_pollutant_value(
+        None, "µg/m³", None, "µg/m³"
+    ),
+}
 
 
 # Test Setup
@@ -241,6 +284,7 @@ seed_api_test_data(
         test_city_b_site_2_2024_7_20_16_30_0,
         test_city_c_site_1_2024_8_20_16_30_0,
         test_city_c_site_2_2024_8_20_17_0_0,
+        invalid_in_situ_document,
     ],
 )
 
@@ -843,3 +887,16 @@ def test__check_measurement_base_time_in_response_is_correct(
 
     for city in response_json:
         assert city.get("measurement_base_time") == test_measurement_base_time_string
+
+
+def test__invalid_document_in_database__assert_500():
+    load_dotenv()
+    api_parameters: dict = {
+        "location_type": location_type,
+        "measurement_base_time": datetime.datetime(
+            2024, 1, 25, 7, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+        "measurement_time_range": measurement_time_range,
+    }
+    response = requests.request("GET", base_url, params=api_parameters, timeout=5.0)
+    assert response.status_code == 500

--- a/air-quality-backend/system_tests/data/forecast_api_test_data.py
+++ b/air-quality-backend/system_tests/data/forecast_api_test_data.py
@@ -35,5 +35,5 @@ def create_forecast_database_data_with_overrides(overrides):
     return {**default_city, **overrides}
 
 
-def create_forecast_api_database_data_pollutant_value(aqi_level: int, value: float):
+def create_forecast_api_database_data_pollutant_value(aqi_level, value):
     return {"aqi_level": aqi_level, "value": value}

--- a/air-quality-backend/system_tests/data/measurement_summary_api_test_data.py
+++ b/air-quality-backend/system_tests/data/measurement_summary_api_test_data.py
@@ -121,7 +121,7 @@ def create_metadata_values(
 
 
 def create_measurement_summary_database_data_pollutant_value(
-    value: float, unit: str, original_value: float, original_unit: str
+    value, unit: str, original_value, original_unit: str
 ):
     return {
         "value": value,


### PR DESCRIPTION
### Description

- Adding test to each seeded data API test file to include checking that malformed documents generate a 500
- removing tech debt related to specifying `.env-qa` in `load_dotenv()`
- added types to test data
- amended test data generation functions to remove types to allow bad documents to be generated