### PR TITLE
Tweaks to get measurements API

### DIFF
--- a/air-quality-backend/src/air_quality/api/measurements_controller.py
+++ b/air-quality-backend/src/air_quality/api/measurements_controller.py
@@ -8,7 +8,7 @@ from air_quality.api.mappers.measurements_mapper import (
     map_measurements,
     map_summarized_measurements,
 )
-from air_quality.api.types import MeasurementSummaryDto, MeasurementDto
+from air_quality.api.types import ApiSource, MeasurementSummaryDto, MeasurementDto
 from air_quality.database.in_situ import get_averaged, find_by_criteria
 from air_quality.database.locations import AirQualityLocationType
 
@@ -20,14 +20,14 @@ async def get_measurements(
     date_from: datetime,
     date_to: datetime,
     location_type: AirQualityLocationType,
-    location_name: List[str] = Query(None),
-    api_source: str = None,
+    location_names: List[str] = Query(None),
+    api_source: ApiSource = None,
 ) -> List[MeasurementDto]:
     log.info(
         f"Fetching measurements between {date_from} - {date_to} for {location_type}"
     )
     db_results = find_by_criteria(
-        date_from, date_to, location_type, location_name, api_source
+        date_from, date_to, location_type, location_names, api_source
     )
 
     log.info(f"Responding with {len(db_results)} results")

--- a/air-quality-backend/src/air_quality/api/types.py
+++ b/air-quality-backend/src/air_quality/api/types.py
@@ -1,8 +1,13 @@
 from datetime import datetime
+from enum import Enum
 
 from typing_extensions import Generic, TypedDict, NotRequired, TypeVar
 
 from air_quality.database.locations import AirQualityLocationType
+
+
+class ApiSource(Enum):
+    OPENAQ = "openaq"
 
 
 class PollutantDataDto(TypedDict):

--- a/air-quality-backend/src/air_quality/database/in_situ.py
+++ b/air-quality-backend/src/air_quality/database/in_situ.py
@@ -1,7 +1,8 @@
 import logging
 from datetime import datetime, timedelta
-from typing import TypedDict, NotRequired, Optional
+from typing import List, TypedDict, NotRequired, Optional
 
+from air_quality.api.types import ApiSource
 from bson import ObjectId
 
 from air_quality.database.locations import AirQualityLocationType
@@ -30,7 +31,7 @@ class InSituMeasurement(TypedDict):
     measurement_date: datetime
     name: str
     location_name: str
-    api_source: str
+    api_source: ApiSource
     created_time: NotRequired[datetime]
     last_modified_time: NotRequired[datetime]
     location: GeoJSONPoint
@@ -73,8 +74,8 @@ def find_by_criteria(
     measurement_date_from: datetime,
     measurement_date_to: datetime,
     location_type: AirQualityLocationType,
-    locations: [str] = None,
-    api_source: str = None,
+    locations: List[str] = None,
+    api_source: ApiSource = None,
 ) -> list[InSituMeasurement]:
     criteria = {
         "measurement_date": {

--- a/air-quality-backend/tests/api/measurements_controller_test.py
+++ b/air-quality-backend/tests/api/measurements_controller_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from air_quality.api.types import ApiSource
 import pytest
 from fastapi.testclient import TestClient
 
@@ -88,8 +89,8 @@ def test__measurements_invalid_query_params__throw_error(field, params, expected
 def test__measurements_applies_appropriate_filters__when_request_valid():
     params = {
         **measurement_request_defaults,
-        "location_name": ["London", "Paris"],
-        "api_source": "test",
+        "location_names": ["London", "Paris"],
+        "api_source": "openaq",
     }
     with patch(
         "air_quality.api.measurements_controller.find_by_criteria", return_value=[]
@@ -102,7 +103,7 @@ def test__measurements_applies_appropriate_filters__when_request_valid():
             datetime(2024, 6, 1, 0, 0),
             AirQualityLocationType.CITY,
             ["London", "Paris"],
-            "test",
+            ApiSource.OPENAQ,
         )
 
 

--- a/air-quality-ui/src/services/measurement-data-service.spec.ts
+++ b/air-quality-ui/src/services/measurement-data-service.spec.ts
@@ -93,7 +93,7 @@ describe('Measurement Data Service', () => {
 
       expect(result).toEqual([])
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringMatching('&location_name=London&location_name=Paris'),
+        expect.stringMatching('&location_names=London&location_names=Paris'),
         expect.anything(),
       )
     })
@@ -103,12 +103,12 @@ describe('Measurement Data Service', () => {
         dateTo,
         'city',
         [],
-        'source',
+        'openaq',
       )
 
       expect(result).toEqual([])
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringMatching('&api_source=source'),
+        expect.stringMatching('&api_source=openaq'),
         expect.anything(),
       )
     })

--- a/air-quality-ui/src/services/measurement-data-service.ts
+++ b/air-quality-ui/src/services/measurement-data-service.ts
@@ -26,7 +26,7 @@ export const getMeasurements = async (
     location_type: locationType,
   }
   if (locations) {
-    params['location_name'] = locations
+    params['location_names'] = locations
   }
   if (apiSource) {
     params['api_source'] = apiSource


### PR DESCRIPTION
Update the get measures API parameters

- location_name is now pluralised to location_names
- apisource is now validating against an ApiSource enum