### PR TITLE
Test Fix - Post-Docker, test change to baseURL used in API tests

### DIFF
--- a/air-quality-backend/system_tests/utils/routes.py
+++ b/air-quality-backend/system_tests/utils/routes.py
@@ -1,5 +1,5 @@
 class Routes:
-    local_base_url = "http://127.0.0.1:8000/air-pollutant"
+    local_base_url = "http://localhost:8000/air-pollutant"
     forecast_api_endpoint = local_base_url + "/forecast"
     measurements_api_endpoint = local_base_url + "/measurements"
     measurements_summary_api_endpoint = measurements_api_endpoint + "/summary"


### PR DESCRIPTION
### Description

- I was experiencing API test failures with the base url using `http://127.0.0.1:8000/air-pollutant`, switching to `local_base_url = http://localhost:8000/air-pollutant` corrected this for me