### PR TITLE
Updated cron script location to match where the dockerfile puts it

### DIFF
--- a/air-quality-backend/cron/crontab.forecast
+++ b/air-quality-backend/cron/crontab.forecast
@@ -1,1 +1,1 @@
-10 10,22 * * * conda run --no-capture-output -n air-quality-backend python "/usr/src/app/scripts/run_forecast_etl.py"
+10 10,22 * * * conda run --no-capture-output -n air-quality-backend python "/app/scripts/run_forecast_etl.py"

--- a/air-quality-backend/cron/crontab.insitu
+++ b/air-quality-backend/cron/crontab.insitu
@@ -1,1 +1,1 @@
-0 */1 * * * conda run --no-capture-output -n air-quality-backend python "/usr/src/app/scripts/run_in_situ_etl.py"
+0 */1 * * * conda run --no-capture-output -n air-quality-backend python "/app/scripts/run_in_situ_etl.py"


### PR DESCRIPTION
The cron job script location needs to match the location the dockerfile adds the files to, referenced here:

https://github.com/ECMWFCode4Earth/vAirify/blob/main/air-quality-backend/Dockerfile.forecast
https://github.com/ECMWFCode4Earth/vAirify/blob/main/air-quality-backend/Dockerfile.insitu