### PR TITLE
CRON pass through logs

### DIFF
--- a/air-quality-backend/Dockerfile.forecast
+++ b/air-quality-backend/Dockerfile.forecast
@@ -34,4 +34,4 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 
 COPY cron/crontab.forecast crontab
 
-CMD [ "/usr/local/bin/supercronic", "./crontab" ]
+CMD [ "/usr/local/bin/supercronic", "-passthrough-logs", "./crontab" ]

--- a/air-quality-backend/Dockerfile.insitu
+++ b/air-quality-backend/Dockerfile.insitu
@@ -34,4 +34,4 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 
 COPY cron/crontab.insitu crontab
 
-CMD [ "/usr/local/bin/supercronic", "./crontab" ]
+CMD [ "/usr/local/bin/supercronic", "-passthrough-logs", "./crontab" ]


### PR DESCRIPTION
Pass through a command line property to SuperCronic to not wrap the scripts logs in super cronic wafle