### PR TITLE
Remove GRIB files

### DIFF
--- a/air-quality-backend/src/air_quality/etl/forecast/forecast_dao.py
+++ b/air-quality-backend/src/air_quality/etl/forecast/forecast_dao.py
@@ -122,5 +122,15 @@ def fetch_forecast_data(
             f"multi_level_{file_ident}.grib",
         ),
     ]
-    results = [fetch_cams_data(*params) for params in task_params]
-    return ForecastData(*results)
+    try:
+        results = [fetch_cams_data(*params) for params in task_params]
+        return ForecastData(*results)
+    finally:
+        keep_files = os.environ.get("STORE_GRIB_FILES", "False") == "True"
+        if not keep_files:
+            [remove_file(file) for _, file in task_params]
+
+
+def remove_file(file: str):
+    logging.info(f"Removing file {file}")
+    os.remove(file)


### PR DESCRIPTION
Remove the relevant GRIB files at the end of the running the ETL script files

This is a configurable option with config key of "STORE_GRIB_FILES". 

The default behaviour is to remove the files, set the value to "True" to keep them 