### PR TITLE
Gridify the charts on city page

### DIFF
--- a/air-quality-ui/src/components/single-city/SingleCity.module.css
+++ b/air-quality-ui/src/components/single-city/SingleCity.module.css
@@ -4,7 +4,7 @@
     flex-direction: column;
     min-height: 80vh;
     justify-content: center;
-    padding: 32px 32px;
+    padding: 10px 32px;
 }
 
 .single-city-section {
@@ -26,11 +26,13 @@
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     padding: 0 0 32px 0;
+    row-gap: 32px;
 }
 
 .site-measurements-section {
     align-items: center;
     padding: 32px 0 32px 0;
+    min-width: 600px;
     max-width: 800px;   
 }
 

--- a/air-quality-ui/src/components/single-city/SingleCity.module.css
+++ b/air-quality-ui/src/components/single-city/SingleCity.module.css
@@ -21,16 +21,17 @@
     flex-direction: column;
 }
 
-.site-measurements-section {
+.chart-section {
     align-items: center;
-    display: flex;
-    flex-direction: column;
-    padding: 32px 0 32px 0;
-    max-width: 800px;   
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    padding: 0 0 32px 0;
 }
 
-.site-measurement-chart {
+.site-measurements-section {
+    align-items: center;
     padding: 32px 0 32px 0;
+    max-width: 800px;   
 }
 
 .site-select-form {

--- a/air-quality-ui/src/components/single-city/SingleCity.module.css
+++ b/air-quality-ui/src/components/single-city/SingleCity.module.css
@@ -26,7 +26,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     padding: 0 0 32px 0;
-    row-gap: 32px;
+    row-gap: 16px;
 }
 
 .site-measurements-section {

--- a/air-quality-ui/src/components/single-city/SingleCity.spec.tsx
+++ b/air-quality-ui/src/components/single-city/SingleCity.spec.tsx
@@ -94,7 +94,6 @@ describe('SingleCityComponent', () => {
         render(<SingleCity />)
       await waitFor(() => {
         expect(screen.getByText('Measurement Sites')).toBeInTheDocument()
-        expect(screen.getByText('Site Measurements')).toBeInTheDocument()
       })
     })
     it('groups data correctly by site for display (all pollutants)', async () => {

--- a/air-quality-ui/src/components/single-city/SingleCity.spec.tsx
+++ b/air-quality-ui/src/components/single-city/SingleCity.spec.tsx
@@ -65,26 +65,6 @@ describe('SingleCityComponent', () => {
       expect(screen.getByText('An error occurred')).toBeInTheDocument()
     })
   })
-  it('shows spinner when loading forecast data', async () => {
-    ;(useQueries as jest.Mock).mockReturnValue([
-      { data: [], isPending: true, isError: false },
-      { data: [], isPending: false, isError: false },
-    ])
-    render(<SingleCity />)
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
-    })
-  })
-  it('shows spinner when loading measurement data', async () => {
-    ;(useQueries as jest.Mock).mockReturnValue([
-      { data: [], isPending: false, isError: false },
-      { data: [], isPending: true, isError: false },
-    ])
-    render(<SingleCity />)
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
-    })
-  })
   describe('when data loaded', () => {
     it('shows the site measurements section', async () => {
       ;(useQueries as jest.Mock).mockReturnValue([
@@ -96,7 +76,7 @@ describe('SingleCityComponent', () => {
         expect(screen.getByText('Measurement Sites')).toBeInTheDocument()
       })
     })
-    it('groups data correctly by site for display (all pollutants)', async () => {
+    it('displays pollutant charts when all have values', async () => {
       ;(useQueries as jest.Mock).mockReturnValue([
         { data: [], isPending: false, isError: false },
         {
@@ -126,7 +106,7 @@ describe('SingleCityComponent', () => {
         })
       })
     })
-    it('groups data correctly by site for display (single pollutant)', async () => {
+    it('displays pollutant charts with no measurement data', async () => {
       ;(useQueries as jest.Mock).mockReturnValue([
         { data: [], isPending: false, isError: false },
         {
@@ -142,16 +122,11 @@ describe('SingleCityComponent', () => {
       ])
       render(<SingleCity />)
       await waitFor(() => {
-        expect(
-          screen.getByTestId(`site_measurements_chart_no2`),
-        ).toBeInTheDocument()
-        pollutantTypes
-          .filter((type) => type !== 'no2')
-          .forEach((type) => {
-            expect(
-              screen.queryByTestId(`site_measurements_chart_${type}`),
-            ).toBeNull()
-          })
+        pollutantTypes.forEach((type) => {
+          expect(
+            screen.queryByTestId(`site_measurements_chart_${type}`),
+          ).toBeInTheDocument()
+        })
       })
     })
     describe('site selection', () => {
@@ -188,7 +163,7 @@ describe('SingleCityComponent', () => {
           ).toBeInTheDocument()
         })
       })
-      it('should hide charts when sites are deselected resulting in no measurements', async () => {
+      it('should still show chart when sites are deselected resulting in no measurements', async () => {
         render(<SingleCity />)
         await act(async () => {
           ;(await screen.findByLabelText('Remove Site 1')).click()
@@ -198,7 +173,7 @@ describe('SingleCityComponent', () => {
           ;['no2', 'o3', 'so2'].forEach((type) => {
             expect(
               screen.queryByTestId(`site_measurements_chart_${type}`),
-            ).toBeNull()
+            ).toBeInTheDocument()
           })
           ;['pm2_5', 'pm10'].forEach((type) => {
             expect(

--- a/air-quality-ui/src/components/single-city/SingleCity.tsx
+++ b/air-quality-ui/src/components/single-city/SingleCity.tsx
@@ -118,6 +118,7 @@ export const SingleCity = () => {
         { pm2_5: {}, pm10: {}, no2: {}, o3: {}, so2: {} },
       )
   }, [measurementData, selectedSites])
+
   const measurements = useMemo(() => {
     return measurementData?.filter((measurement) =>
       selectedSites.find(
@@ -125,6 +126,7 @@ export const SingleCity = () => {
       ),
     )
   }, [measurementData, selectedSites])
+
   const [siteColors, setSiteColors] = useState<Record<string, string>>({})
   useEffect(() => {
     const updateColors = async () => {
@@ -137,6 +139,7 @@ export const SingleCity = () => {
     }
     updateColors()
   }, [sites])
+
   const deselectSite = useCallback((siteName: string) => {
     setSelectedSites((current) =>
       current.filter(({ value }) => value !== siteName),
@@ -152,15 +155,34 @@ export const SingleCity = () => {
       {(forecastDataPending || measurementDataPending) && <LoadingSpinner />}
       {!forecastDataPending && !measurementDataPending && (
         <>
-          <section
-            data-testid="main-comparison-chart"
-            className={classes['single-city-section']}
-          >
-            <AverageComparisonChart
-              forecastData={forecastData}
-              measurementsData={measurements}
-              forecastBaseTime={forecastBaseDate}
-            />
+          <section className={classes['chart-section']}>
+            <div key="aqi_chart" data-testid="aqi_chart">
+              <AverageComparisonChart
+                forecastData={forecastData}
+                measurementsData={measurements}
+                forecastBaseTime={forecastBaseDate}
+              />
+            </div>
+            {measurementsByPollutantBySite &&
+              Object.entries(measurementsByPollutantBySite)
+                .filter(
+                  ([, measurementsBySite]) =>
+                    !!Object.keys(measurementsBySite).length,
+                )
+                .map(([pollutantType, measurementsBySite]) => (
+                  <div
+                    key={`site_measurements_chart_${pollutantType}`}
+                    data-testid={`site_measurements_chart_${pollutantType}`}
+                  >
+                    <SiteMeasurementsChart
+                      forecastData={forecastData}
+                      measurementsBySite={measurementsBySite}
+                      onSiteClick={deselectSite}
+                      pollutantType={pollutantType as PollutantType}
+                      seriesColorsBySite={siteColors}
+                    />
+                  </div>
+                ))}
           </section>
           <section className={classes['site-measurements-section']}>
             <form
@@ -184,30 +206,6 @@ export const SingleCity = () => {
                 value={selectedSites}
               />
             </form>
-          </section>
-          <section className={classes['site-measurements-section']}>
-            <h3>Site Measurements</h3>
-            {measurementsByPollutantBySite &&
-              Object.entries(measurementsByPollutantBySite)
-                .filter(
-                  ([, measurementsBySite]) =>
-                    !!Object.keys(measurementsBySite).length,
-                )
-                .map(([pollutantType, measurementsBySite]) => (
-                  <div
-                    key={`site_measurements_chart_${pollutantType}`}
-                    data-testid={`site_measurements_chart_${pollutantType}`}
-                    className={classes['site-measurement-chart']}
-                  >
-                    <SiteMeasurementsChart
-                      forecastData={forecastData}
-                      measurementsBySite={measurementsBySite}
-                      onSiteClick={deselectSite}
-                      pollutantType={pollutantType as PollutantType}
-                      seriesColorsBySite={siteColors}
-                    />
-                  </div>
-                ))}
           </section>
         </>
       )}

--- a/air-quality-ui/src/components/single-city/SingleCity.tsx
+++ b/air-quality-ui/src/components/single-city/SingleCity.tsx
@@ -164,12 +164,8 @@ export const SingleCity = () => {
               />
             </div>
             {measurementsByPollutantBySite &&
-              Object.entries(measurementsByPollutantBySite)
-                .filter(
-                  ([, measurementsBySite]) =>
-                    !!Object.keys(measurementsBySite).length,
-                )
-                .map(([pollutantType, measurementsBySite]) => (
+              Object.entries(measurementsByPollutantBySite).map(
+                ([pollutantType, measurementsBySite]) => (
                   <div
                     key={`site_measurements_chart_${pollutantType}`}
                     data-testid={`site_measurements_chart_${pollutantType}`}
@@ -182,7 +178,8 @@ export const SingleCity = () => {
                       seriesColorsBySite={siteColors}
                     />
                   </div>
-                ))}
+                ),
+              )}
           </section>
           <section className={classes['site-measurements-section']}>
             <form

--- a/air-quality-ui/src/components/single-city/average-comparison-chart/AverageComparisonChart.module.css
+++ b/air-quality-ui/src/components/single-city/average-comparison-chart/AverageComparisonChart.module.css
@@ -1,4 +1,4 @@
 .chart {
     height: 400px !important;
-    width: 100%;
+    width: 600px;
 }

--- a/air-quality-ui/src/components/single-city/average-comparison-chart/average-composition-chart-builder.spec.ts
+++ b/air-quality-ui/src/components/single-city/average-comparison-chart/average-composition-chart-builder.spec.ts
@@ -1,4 +1,8 @@
-import { YAXisComponentOption } from 'echarts'
+import {
+  LegendComponentOption,
+  TitleComponentOption,
+  YAXisComponentOption,
+} from 'echarts'
 
 import { getForecastOptions } from './average-composition-chart-builder'
 import { AverageAqiValues } from '../../../services/calculate-measurements-aqi-averages/calculate-measurement-aqi-averages-service'
@@ -62,6 +66,25 @@ describe('AverageComparisonChart', () => {
       measurementDate: '2024-01-02T00:00:00Z',
     },
   ]
+
+  describe('legend', () => {
+    it('is positioned on right', async () => {
+      const result = getForecastOptions(testForecastData, testMeasurementData)
+      expect((result.legend as LegendComponentOption).left).toBe('right')
+    })
+  })
+
+  describe('title', () => {
+    it('says AQI', async () => {
+      const result = getForecastOptions(testForecastData, testMeasurementData)
+      expect((result.title as TitleComponentOption).text).toBe('AQI')
+    })
+
+    it('is in the center', async () => {
+      const result = getForecastOptions(testForecastData, testMeasurementData)
+      expect((result.title as TitleComponentOption).left).toBe('center')
+    })
+  })
 
   describe('yAxis', () => {
     it('label is AQI', async () => {

--- a/air-quality-ui/src/components/single-city/average-comparison-chart/average-composition-chart-builder.ts
+++ b/air-quality-ui/src/components/single-city/average-comparison-chart/average-composition-chart-builder.ts
@@ -9,6 +9,10 @@ import { ForecastResponseDto } from '../../../services/types'
 
 export const getOptions = (): EChartsOption => {
   return {
+    title: {
+      text: 'AQI',
+      left: 'center',
+    },
     xAxis: {
       type: 'time',
       axisLabel: {
@@ -25,7 +29,10 @@ export const getOptions = (): EChartsOption => {
     tooltip: {
       trigger: 'axis',
     },
-    legend: {},
+    legend: {
+      left: 'right',
+      padding: [40, 60],
+    },
   }
 }
 

--- a/air-quality-ui/src/components/single-city/site-measurement-chart/SiteMeasurementsChart.module.css
+++ b/air-quality-ui/src/components/single-city/site-measurement-chart/SiteMeasurementsChart.module.css
@@ -5,5 +5,5 @@
 
 .chart {
     height: 400px !important;
-    min-width: 800px !important;
+    width: 600px;
 }

--- a/air-quality-ui/src/components/single-city/site-measurement-chart/SiteMeasurementsChart.spec.tsx
+++ b/air-quality-ui/src/components/single-city/site-measurement-chart/SiteMeasurementsChart.spec.tsx
@@ -1,9 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
 import { DateTime } from 'luxon'
 
 import { SiteMeasurementsChart } from './SiteMeasurementsChart'
-import { PollutantType } from '../../../models'
 
 jest.mock('echarts-for-react', () => () => <div>Mock Chart</div>)
 
@@ -15,25 +14,18 @@ jest.mock('../../../context', () => ({
   }),
 }))
 
-describe('SiteMeasurementChart', () => {
-  it.each<[PollutantType, string]>([
-    ['no2', 'Nitrogen Dioxide'],
-    ['so2', 'Sulphur Dioxide'],
-    ['o3', 'Ozone'],
-    ['pm10', 'PM 10'],
-    ['pm2_5', 'PM 2.5'],
-  ])(
-    'should display the correct label for pollutant: %s',
-    (pollutantType, expectedLabel) => {
-      render(
-        <SiteMeasurementsChart
-          forecastData={[]}
-          measurementsBySite={{}}
-          pollutantType={pollutantType}
-          onSiteClick={() => {}}
-        />,
-      )
-      expect(screen.getByText(expectedLabel)).toBeInTheDocument()
-    },
-  )
+describe('AverageComparisonChart', () => {
+  it('renders with forecast data and measurement data', async () => {
+    render(
+      <SiteMeasurementsChart
+        forecastData={[]}
+        measurementsBySite={{}}
+        pollutantType={'pm10'}
+        onSiteClick={() => {}}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Mock Chart')).toBeInTheDocument()
+    })
+  })
 })

--- a/air-quality-ui/src/components/single-city/site-measurement-chart/SiteMeasurementsChart.tsx
+++ b/air-quality-ui/src/components/single-city/site-measurement-chart/SiteMeasurementsChart.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react'
 import { generateMeasurementChart } from './site-measurement-chart-builder'
 import classes from './SiteMeasurementsChart.module.css'
 import { useForecastContext } from '../../../context'
-import { PollutantType, pollutantTypeDisplay } from '../../../models'
+import { PollutantType } from '../../../models'
 import { getInSituPercentage } from '../../../services/forecast-time-service'
 import {
   ForecastResponseDto,
@@ -59,9 +59,6 @@ export const SiteMeasurementsChart = ({
 
   return (
     <>
-      <label className={classes['chart-label']}>
-        {pollutantTypeDisplay[pollutantType]}
-      </label>
       <ReactECharts
         className={classes['chart']}
         onEvents={{

--- a/air-quality-ui/src/components/single-city/site-measurement-chart/site-measurement-chart-builder.spec.ts
+++ b/air-quality-ui/src/components/single-city/site-measurement-chart/site-measurement-chart-builder.spec.ts
@@ -1,6 +1,7 @@
 import {
   DataZoomComponentOption,
   LineSeriesOption,
+  TitleComponentOption,
   YAXisComponentOption,
 } from 'echarts'
 
@@ -93,6 +94,26 @@ describe('Site Measurement Chart', () => {
       ...forecastBaseData,
     },
   ]
+  describe('title', () => {
+    it.each<[PollutantType, string]>([
+      ['no2', 'Nitrogen Dioxide'],
+      ['so2', 'Sulphur Dioxide'],
+      ['o3', 'Ozone'],
+      ['pm10', 'PM 10'],
+      ['pm2_5', 'PM 2.5'],
+    ])(
+      `shows the correct pollutant`,
+      async (title: PollutantType, expected: string) => {
+        const result = generateMeasurementChart(
+          title,
+          zoomPercent,
+          measurementsBySite,
+          forecastData,
+        )
+        expect((result.title as TitleComponentOption).text).toBe(expected)
+      },
+    )
+  })
 
   describe('yAxis', () => {
     it('label is AQI', async () => {

--- a/air-quality-ui/src/components/single-city/site-measurement-chart/site-measurement-chart-builder.ts
+++ b/air-quality-ui/src/components/single-city/site-measurement-chart/site-measurement-chart-builder.ts
@@ -1,6 +1,6 @@
 import { EChartsOption, SeriesOption } from 'echarts'
 
-import { PollutantType } from '../../../models'
+import { PollutantType, pollutantTypeDisplay } from '../../../models'
 import { convertToLocalTime } from '../../../services/echarts-service'
 import {
   ForecastResponseDto,
@@ -56,8 +56,15 @@ const createMeasurementSeries = (
     symbol: 'roundRect',
   }))
 
-const createChartOptions = (zoomPercent: number): EChartsOption => {
+const createChartOptions = (
+  chartTitle: string,
+  zoomPercent: number,
+): EChartsOption => {
   return {
+    title: {
+      text: chartTitle,
+      left: 'center',
+    },
     xAxis: {
       type: 'time',
     },
@@ -91,7 +98,9 @@ export const generateMeasurementChart = (
     seriesColorsBySite,
   )
   const forecast = createForecastSeries(pollutantType, forecastData)
-  const options = createChartOptions(zoomPercent)
+
+  const chartTile = pollutantTypeDisplay[pollutantType]
+  const options = createChartOptions(chartTile, zoomPercent)
 
   return {
     ...options,


### PR DESCRIPTION
Make the charts appear in a grid.

Titles are now part of the chart instead of separate component
All charts are displayed, even when there is no measurement data

![image](https://github.com/user-attachments/assets/cc7f746d-b2b2-4487-80de-9e717526c427)
