### PR TITLE
Use node 22.4 for UI docker

### DIFF
--- a/air-quality-ui/Dockerfile
+++ b/air-quality-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS development
+FROM node:22.4.0-alpine AS development
 
 WORKDIR /app
 


### PR DESCRIPTION
Use node 22.4 for the base docker image

Since node 22.5 was released on 18-07-2024 the docker image for the UI has not been building.

Rolling back to previous version appears to recitify issue.