### PR TITLE
Changed hashing library to fix: BUG Sort out the colour updates for the measurement station lines #257

### DIFF
--- a/air-quality-ui/package-lock.json
+++ b/air-quality-ui/package-lock.json
@@ -17,6 +17,7 @@
         "echarts": "^5.5.0",
         "echarts-for-react": "^3.0.2",
         "jest-each": "^29.7.0",
+        "js-sha1": "^0.7.0",
         "luxon": "^3.4.4",
         "maplibre-gl": "^4.5.0",
         "prettier": "^3.3.2",
@@ -8743,6 +8744,11 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/js-sha1": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.7.0.tgz",
+      "integrity": "sha512-oQZ1Mo7440BfLSv9TX87VNEyU52pXPVG19F9PL3gTgNt0tVxlZ8F4O6yze3CLuLx28TxotxvlyepCNaaV0ZjMw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/air-quality-ui/package.json
+++ b/air-quality-ui/package.json
@@ -23,6 +23,7 @@
     "echarts": "^5.5.0",
     "echarts-for-react": "^3.0.2",
     "jest-each": "^29.7.0",
+    "js-sha1": "^0.7.0",
     "luxon": "^3.4.4",
     "maplibre-gl": "^4.5.0",
     "prettier": "^3.3.2",

--- a/air-quality-ui/src/services/echarts-service.ts
+++ b/air-quality-ui/src/services/echarts-service.ts
@@ -1,3 +1,4 @@
+import { sha1 } from 'js-sha1'
 import { DateTime } from 'luxon'
 
 /**
@@ -38,7 +39,7 @@ export const textToColor = async (text: string): Promise<string> => {
   const generateHash = async (text: string): Promise<ArrayBuffer> => {
     const encoder = new TextEncoder()
     const data = encoder.encode(text)
-    return await crypto.subtle.digest('SHA-256', data)
+    return await sha1.arrayBuffer(data)
   }
 
   // Convert the hash to a hexadecimal string


### PR DESCRIPTION
Changed hashing library to fix: BUG Sort out the colour updates for the measurement station lines #257
Now using: https://www.npmjs.com/package/js-sha1

I think we are getting this error because our website is not using HTTPS and SubtleCrypto: digest() requires it for it to work. That would explain why it works locally as it considers this safe and not on prod.
https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
Warning at the top explains