### PR TITLE
Restyle select component

### DIFF
--- a/air-quality-ui/src/components/header/ForecastWindowSelector.spec.tsx
+++ b/air-quality-ui/src/components/header/ForecastWindowSelector.spec.tsx
@@ -12,7 +12,7 @@ describe('ForecastWindowSelector component', () => {
       />,
     )
     await waitFor(() => {
-      expect(screen.getByText('Forecast Window')).toBeInTheDocument()
+      expect(screen.getByText('Forecast Days')).toBeInTheDocument()
     })
   })
   it('Select box is present', async () => {

--- a/air-quality-ui/src/components/header/ForecastWindowSelector.tsx
+++ b/air-quality-ui/src/components/header/ForecastWindowSelector.tsx
@@ -25,7 +25,7 @@ const selectStyling: StylesConfig = {
     ...baseStyles,
     background: 'black',
     height: '100%',
-    borderColor: state.isFocused ? 'white' : '#444',
+    borderColor: state.isFocused ? 'white' : '#3b3b3b',
   }),
   singleValue: (baseStyles) => ({
     ...baseStyles,
@@ -35,9 +35,25 @@ const selectStyling: StylesConfig = {
     ...baseStyles,
     color: 'white',
   }),
+  dropdownIndicator: (baseStyles) => ({
+    ...baseStyles,
+    cursor: 'pointer',
+  }),
+  option: (baseStyles, state) => ({
+    ...baseStyles,
+    cursor: 'pointer',
+    color: state.isSelected ? '#2f2f2f' : 'white',
+    backgroundColor: state.isSelected
+      ? state.isFocused
+        ? '#62a5f4'
+        : '#9ecaf8'
+      : state.isFocused
+        ? '#373b3e'
+        : baseStyles.backgroundColor,
+  }),
   menu: (baseStyles) => ({
     ...baseStyles,
-    color: 'black',
+    backgroundColor: '#2f2f2f',
   }),
 }
 

--- a/air-quality-ui/src/components/header/ForecastWindowSelector.tsx
+++ b/air-quality-ui/src/components/header/ForecastWindowSelector.tsx
@@ -44,9 +44,7 @@ const selectStyling: StylesConfig = {
 export const ForecastWindowSelector = (props: ForecastWindowSelectorProps) => {
   return (
     <div>
-      <label className={classes['forecast-window-label']}>
-        Forecast Window
-      </label>
+      <label className={classes['forecast-window-label']}>Forecast Days</label>
       <Select
         className={classes['forecast-window-select']}
         inputId="forecast-window-select"

--- a/air-quality-ui/src/components/header/Toolbar.spec.tsx
+++ b/air-quality-ui/src/components/header/Toolbar.spec.tsx
@@ -89,7 +89,7 @@ describe('Toolbar component', () => {
         DateTime.fromISO('2024-06-10T09:00:00', { zone: 'utc' }),
       )
     })
-    fireEvent.click(screen.getByText('Ok'))
+    fireEvent.click(screen.getByText('Update'))
     await waitFor(() => {
       expect(mockSetDetails).toHaveBeenCalledWith({
         forecastBaseDate: DateTime.fromISO('2024-06-10T09:00:00', {
@@ -109,7 +109,7 @@ describe('Toolbar component', () => {
     await waitFor(() => {
       setIsInvalidDateTime(true)
     })
-    fireEvent.click(screen.getByText('Ok'))
+    fireEvent.click(screen.getByText('Update'))
     await waitFor(() => {
       expect(mockSetDetails).not.toHaveBeenCalledWith(
         DateTime.fromISO('2024-08-10T09:00:00', { zone: 'utc' }),
@@ -145,7 +145,7 @@ describe('Toolbar component', () => {
       await waitFor(() => {
         setSelectedForecastWindow(testData)
       })
-      fireEvent.click(screen.getByText('Ok'))
+      fireEvent.click(screen.getByText('Update'))
       await waitFor(() => {
         expect(beforeSetting).toStrictEqual({ value: 1, label: '1' })
       })

--- a/air-quality-ui/src/components/header/Toolbar.tsx
+++ b/air-quality-ui/src/components/header/Toolbar.tsx
@@ -54,7 +54,7 @@ export const Toolbar = () => {
                 })
               }
             }}
-            text={'Ok'}
+            text={'Update'}
             isButtonDisabled={isInvalidDateTime}
           />
         </div>


### PR DESCRIPTION
Style the dropdown Forecast Window to match better with the other components

Rename the component label from 'Forecast Window' to 'Forecast Days'

Relabel the 'Ok' button to 'Update'
![image](https://github.com/user-attachments/assets/3f91cff8-b772-4748-adb2-986f0017a13b)
