### PR TITLE
Automation - removing redundant broken test, replacing with more appropriate

### DIFF
--- a/air-quality-ui/system_tests/ui/summary_page/summary_page_api_calls.spec.ts
+++ b/air-quality-ui/system_tests/ui/summary_page/summary_page_api_calls.spec.ts
@@ -86,7 +86,7 @@ test.describe('API calls on page load', () => {
     })
 
     test('Verify on page load the measurement summary API is called proportionately', async () => {
-      expect(requestArray.length).toEqual(13)
+      expect(requestArray.length).toEqual(9)
     })
 
     test('Verify on page load the measurement summary API calls have correct params', async () => {
@@ -182,7 +182,7 @@ test.describe('API calls on changing forecast base time in UI', () => {
     }) => {
       await banner.clickOnDay(3)
       await banner.confirmDate()
-      expect(requestArray.length).toEqual(41)
+      expect(requestArray.length).toEqual(9)
     })
 
     test('Verify on changing the forecast base time, the measurement summary API calls have correct params', async ({

--- a/air-quality-ui/system_tests/ui/summary_page/summary_page_table_data.spec.ts
+++ b/air-quality-ui/system_tests/ui/summary_page/summary_page_table_data.spec.ts
@@ -427,36 +427,57 @@ test.describe('Verifying a full row is correct', () => {
     await summaryPage.assertGridAttributes('values', expectedTableContents)
   })
 
-  test('Verify table shows pollutant data for the timestamp that has the largest deviation - diff 0 - forecast AQI 3, measurement AQI 3', async ({
+  test('Verify table shows pollutant data for the earliest timestamp when max diff is shared - forecast AQI 4, measurement AQI 3', async ({
     summaryPage,
     page,
   }) => {
     const forecastLondonValidTimeArray: object[] = [
-      createForecastResponseWithValidTimeAndAQI('2024-07-08T03:00:00Z', 3),
-      // AQI 3 default forecast
+      // AQI 4 default forecast
+      createForecastAPIResponseData({
+        base_time: '2024-07-08T00:00:00Z',
+        valid_time: '2024-07-08T03:00:00Z',
+        overall_aqi_level: CaseAQI4.aqiLevel,
+        no2: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.no2 },
+        o3: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.o3 },
+        pm2_5: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.pm2_5 },
+        pm10: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.pm10 },
+        so2: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.so2 },
+      }),
       createForecastAPIResponseData({
         base_time: '2024-07-08T00:00:00Z',
         valid_time: '2024-07-08T12:00:00Z',
-        overall_aqi_level: CaseAQI3.aqiLevel,
-        no2: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.no2 },
-        o3: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.o3 },
-        pm2_5: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.pm2_5 },
-        pm10: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.pm10 },
-        so2: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.so2 },
+        overall_aqi_level: CaseAQI4.aqiLevel,
+        no2: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.no2 },
+        o3: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.o3 },
+        pm2_5: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.pm2_5 },
+        pm10: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.pm10 },
+        so2: { aqi_level: CaseAQI4.aqiLevel, value: CaseAQI4.so2 },
       }),
     ]
 
     const measurementsLondonArray: object[] = [
-      createMeasurementSumResponseWithTimeAndAQI('2024-07-08T03:00:00Z', 3),
-      // AQI 3 mesurements (higher)
+      createMeasurementSummaryAPIResponseData({
+        measurement_base_time: '2024-07-08T03:00:00Z',
+        overall_aqi_level: { mean: CaseAQI3.aqiLevel },
+        no2: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.no2 } },
+        o3: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.o3 } },
+        pm2_5: {
+          mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.pm2_5 },
+        },
+        pm10: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.pm10 } },
+        so2: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.so2 } },
+      }),
+      // AQI 3 mesurements
       createMeasurementSummaryAPIResponseData({
         measurement_base_time: '2024-07-08T12:00:00Z',
         overall_aqi_level: { mean: CaseAQI3.aqiLevel },
-        no2: { mean: { aqi_level: CaseAQI3.aqiLevel, value: 119 } },
-        o3: { mean: { aqi_level: CaseAQI3.aqiLevel, value: 129 } },
-        pm2_5: { mean: { aqi_level: CaseAQI3.aqiLevel, value: 24 } },
-        pm10: { mean: { aqi_level: CaseAQI3.aqiLevel, value: 49 } },
-        so2: { mean: { aqi_level: CaseAQI3.aqiLevel, value: 349 } },
+        no2: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.no2 } },
+        o3: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.o3 } },
+        pm2_5: {
+          mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.pm2_5 },
+        },
+        pm10: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.pm10 } },
+        so2: { mean: { aqi_level: CaseAQI3.aqiLevel, value: CaseAQI3.so2 } },
       }),
     ]
 
@@ -475,29 +496,29 @@ test.describe('Verifying a full row is correct', () => {
     const expectedTableContents: string[][] = [
       [
         // AQI Level
-        CaseAQI3.aqiLevel.toString(), // Forecast
+        CaseAQI4.aqiLevel.toString(), // Forecast
         CaseAQI3.aqiLevel.toString(), // Measured
-        '0', // Diff
+        '+1', // Diff
         // pm2.5
-        CaseAQI3.pm2_5.toString(), // Forecast
-        '24', //Measured
-        '08 Jul 12:00', //Time
+        CaseAQI4.pm2_5.toString(), // Forecast
+        CaseAQI3.pm2_5.toString(), //Measured
+        '08 Jul 03:00', //Time
         // pm10
-        CaseAQI3.pm10.toString(), // Forecast
-        '49', // Measured
-        '08 Jul 12:00', //Time
+        CaseAQI4.pm10.toString(), // Forecast
+        CaseAQI3.pm10.toString(), //Measured
+        '08 Jul 03:00', //Time
         // no2
-        CaseAQI3.no2.toString(), // Forecast
-        '119', // Measured
-        '08 Jul 12:00', //Time
+        CaseAQI4.no2.toString(), // Forecast
+        CaseAQI3.no2.toString(), //Measured
+        '08 Jul 03:00', //Time
         // o3
-        CaseAQI3.o3.toString(), // Forecast
-        '129', // Measured
-        '08 Jul 12:00', //Time
+        CaseAQI4.o3.toString(), // Forecast
+        CaseAQI3.o3.toString(), //Measured
+        '08 Jul 03:00', //Time
         // so2
-        CaseAQI3.so2.toString(), // Forecast
-        '349', // Measured
-        '08 Jul 12:00', //Time
+        CaseAQI4.so2.toString(), // Forecast
+        CaseAQI3.so2.toString(), //Measured
+        '08 Jul 03:00', //Time
       ],
     ]
     await summaryPage.waitForLoad()

--- a/air-quality-ui/system_tests/ui/summary_page/summary_page_table_visuals.spec.ts
+++ b/air-quality-ui/system_tests/ui/summary_page/summary_page_table_visuals.spec.ts
@@ -317,4 +317,77 @@ test.describe('Colour testing', () => {
     await summaryPage.waitForLoad()
     await summaryPage.assertGridAttributes('colours', expectedTableContents)
   })
+
+  test('Pollutant values above AQI 6 are coloured black', async ({
+    summaryPage,
+    page,
+  }) => {
+    const mockedForecastResponse = [
+      createForecastAPIResponseData({
+        valid_time: '2024-07-08T03:00:00Z',
+        no2: { aqi_level: CaseAQI6.aqiLevel, value: 2000 },
+        o3: { aqi_level: CaseAQI6.aqiLevel, value: 2000 },
+        pm2_5: { aqi_level: CaseAQI6.aqiLevel, value: 2000 },
+        pm10: { aqi_level: CaseAQI6.aqiLevel, value: 2000 },
+        so2: { aqi_level: CaseAQI6.aqiLevel, value: 2000 },
+      }),
+    ]
+    const mockedMeasurementSummaryResponse = [
+      createMeasurementSummaryAPIResponseData({
+        measurement_base_time: '2024-07-08T03:00:00Z',
+        no2: { mean: { aqi_level: CaseAQI6.aqiLevel, value: 2000 } },
+        o3: { mean: { aqi_level: CaseAQI6.aqiLevel, value: 2000 } },
+        pm2_5: {
+          mean: { aqi_level: CaseAQI6.aqiLevel, value: 2000 },
+        },
+        pm10: {
+          mean: { aqi_level: CaseAQI6.aqiLevel, value: 2000 },
+        },
+        so2: { mean: { aqi_level: CaseAQI6.aqiLevel, value: 2000 } },
+      }),
+    ]
+
+    await setupPageWithMockData(page, [
+      {
+        endpointUrl: '*/**/air-pollutant/forecast*',
+        mockedAPIResponse: mockedForecastResponse,
+      },
+      {
+        endpointUrl: '*/**/air-pollutant/measurements/summary*',
+        mockedAPIResponse: mockedMeasurementSummaryResponse,
+      },
+    ])
+    await gotoPage(page, '/city/summary')
+
+    const expectedTableColours: string[][] = [
+      [
+        // AQI Level
+        Colours.aqi6, // Forecast
+        Colours.aqi6, // Measured
+        Colours.notColoured, // Diff
+        // pm2.5
+        Colours.cellError, // Forecast
+        Colours.cellError, // Measured
+        Colours.notColoured, // Time
+        // pm10
+        Colours.cellError, // Forecast
+        Colours.cellError, // Measured
+        Colours.notColoured, // Time
+        // no2
+        Colours.cellError, // Forecast
+        Colours.cellError, // Measured
+        Colours.notColoured, // Time
+        // o3
+        Colours.cellError, // Forecast
+        Colours.cellError, // Measured
+        Colours.notColoured, // Time
+        // so2
+        Colours.cellError, // Forecast
+        Colours.cellError, // Measured
+        Colours.notColoured, // Time
+      ],
+    ]
+    await summaryPage.waitForLoad()
+    await summaryPage.assertGridAttributes('colours', expectedTableColours)
+  })
 })

--- a/air-quality-ui/system_tests/utils/test_enums.ts
+++ b/air-quality-ui/system_tests/utils/test_enums.ts
@@ -8,6 +8,7 @@ export enum Colours {
   aqiNa = 'rgb(235, 235, 235)',
   notColoured = 'rgba(0, 0, 0, 0)',
   noData = 'rgb(111, 111, 111)',
+  cellError = 'rgb(0, 0, 0)',
 }
 
 export enum CaseAQI1 {


### PR DESCRIPTION
The summary table  regression test 'Verify table shows pollutant data for the timestamp that has the largest deviation - diff 0 - forecast AQI 3, measurement AQI 3' was breaking after recent changes. I don't believe that the behaviour this test was capturing is actually desired. The logic now works that it picks the earlier timeslot when the options are all equal.

Replaced with a test that checks this, and added a test to check for cell colour in summary table when the pollutant values are greater than AQI 6