### PR TITLE
Small UX tweaks

### DIFF
--- a/air-quality-ui/src/components/header/Breadcrumbs.module.css
+++ b/air-quality-ui/src/components/header/Breadcrumbs.module.css
@@ -10,6 +10,11 @@
     padding: 0 8px 0 8px;
 }
 
+.breadcrumb:first-child {
+    width: 2.5em;
+    text-align: center;
+}
+
 .breadcrumb-link {
     color: white;
     text-decoration: none;

--- a/air-quality-ui/src/components/header/Breadcrumbs.module.css
+++ b/air-quality-ui/src/components/header/Breadcrumbs.module.css
@@ -15,7 +15,6 @@
     text-decoration: none;
 
     &:hover {
-        border-bottom: solid 2px white;
         font-weight: bold;
     }
 }

--- a/air-quality-ui/src/components/summary-grid/table/GlobalSummaryTable.tsx
+++ b/air-quality-ui/src/components/summary-grid/table/GlobalSummaryTable.tsx
@@ -32,6 +32,9 @@ export interface GlobalSummaryTableProps {
 }
 
 const maxWidth = 115
+const forecastWidth = 85
+const measurementWidth = 85
+const diffWidth = 60
 
 function insertEmptyValueDash(value: number | undefined): string {
   if (value === undefined) {
@@ -61,7 +64,7 @@ const createColDefs = (showAllColoured: boolean): (ColDef | ColGroupDef)[] => [
         field: 'forecast.aqiLevel',
         headerName: 'Forecast',
         headerClass: 'cell-header-format',
-        maxWidth: maxWidth,
+        maxWidth: forecastWidth,
         cellClass: 'cell-format',
         cellClassRules: aqiCellRules(),
         valueFormatter: (params: ValueFormatterParams) =>
@@ -71,7 +74,7 @@ const createColDefs = (showAllColoured: boolean): (ColDef | ColGroupDef)[] => [
         field: 'measurements.aqiLevel',
         headerName: 'Measured',
         headerClass: 'cell-header-format',
-        maxWidth: maxWidth,
+        maxWidth: measurementWidth,
         cellClass: 'cell-format',
         cellClassRules: aqiCellRules(),
         valueFormatter: (params: ValueFormatterParams) =>
@@ -82,7 +85,7 @@ const createColDefs = (showAllColoured: boolean): (ColDef | ColGroupDef)[] => [
         headerName: 'Diff',
         headerClass: 'cell-header-format',
         sort: 'desc',
-        maxWidth: maxWidth,
+        maxWidth: diffWidth,
         cellClass: 'cell-format',
         valueFormatter: (params: ValueFormatterParams): string => {
           if (!params.data.measurements) {
@@ -104,7 +107,7 @@ const createColDefs = (showAllColoured: boolean): (ColDef | ColGroupDef)[] => [
         headerClass: 'cell-header-format',
         cellClass: 'cell-format',
         cellClassRules: pollutantCellRules(showAllColoured, type),
-        maxWidth: maxWidth,
+        maxWidth: forecastWidth,
         valueFormatter: (params: ValueFormatterParams) =>
           insertEmptyValueDash(params.value),
       },
@@ -114,7 +117,7 @@ const createColDefs = (showAllColoured: boolean): (ColDef | ColGroupDef)[] => [
         headerClass: 'cell-header-format',
         cellClass: 'cell-format',
         cellClassRules: pollutantCellRules(showAllColoured, type),
-        maxWidth: maxWidth,
+        maxWidth: measurementWidth,
         valueFormatter: (params: ValueFormatterParams) =>
           insertEmptyValueDash(params.value),
       },


### PR DESCRIPTION
PR improves some UI elements

- improves the summary table width so that all columns fit in one screen
- remove underline on hover of 'cities' on single city page
- stop breadcrumbs shifting on hover of 'cities' line on single city page