### PR TITLE
Test - fix forecast calibration test to round appropriately #345

### DIFF
--- a/air-quality-backend/system_tests/utils/cams_utilities.py
+++ b/air-quality-backend/system_tests/utils/cams_utilities.py
@@ -1,3 +1,4 @@
+import pprint
 from datetime import datetime
 from pandas import read_csv
 
@@ -127,6 +128,17 @@ def get_forecast_percentage_divergence(
         pollutant, "database_forecast", database_record_for_city_and_valid_time
     )
 
+    database_pollutant_value_3dp = round(database_pollutant_value, 3)
+
+    pprint.pprint(
+        "City: {}, Pollutant: {}, ECMWF value: {}, database value: {}".format(
+            test_city,
+            pollutant,
+            ecmwf_forecast_pollutant_value,
+            database_pollutant_value_3dp,
+        )
+    )
+
     return calculate_database_divergence_from_ecmwf_forecast_values(
-        database_pollutant_value, ecmwf_forecast_pollutant_value
+        database_pollutant_value_3dp, ecmwf_forecast_pollutant_value
     )


### PR DESCRIPTION
Due to a problem described [here](https://github.com/orgs/ECMWFCode4Earth/projects/12/views/1?pane=issue&itemId=79548750), it would be beneficial for the test to round the db value to 3dp to compare like for like with the FTP value