### PR TITLE
PR workflow fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Use LF for all text files
+* text eol=lf
+
+# Image files are auto detected
+*.gif -text
+*.jpg -text
+*.jpeg -text
+*.pdf -text
+*.png -text
+*.webp -text
+
+# Binary data files
+*.db binary
+*.grib binary
+*.idx binary

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,8 +1,7 @@
 name: pr-build
 
 on:
-  pull_request:
-    types: ['opened', 'reopened', 'synchronize']
+  pull_request_target:
     branches:
       - 'main'
 
@@ -192,7 +191,7 @@ jobs:
         working-directory: 'air-quality-ui'
 
       - name: Run tests with coverage
-        uses: ArtiomTr/jest-coverage-report-action@v2.0-rc.6
+        uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: 'air-quality-ui'


### PR DESCRIPTION
Setting the workflow trigger to "pull-request-target" allows (safely) write permissions on the PR, which is needed for the test coverage report job when the PR is opened from a fork of the main repository.

I have also added a gitattributes for consistent line-endings, as previously when checking out the repo on a windows machine, line-endings were converted to CRLF which caused the eslint prettier plugin to complain about every line in every file 😱

resolves #353 